### PR TITLE
Fix CodeQL alert, update license refs, upgrade Go 1.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,4 +99,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `providers.json` configuration with `providers.example.json` template
 - Docker Compose stack (`docker-compose.yml`, `docker-compose-db.yml`, `docker-compose-app.yml`)
 - Helper scripts in `scripts/`: `start-stack.sh`, `update_models.sh`, `test_chat_request.sh`, `generate-swagger.sh`
-- MIT License
+- Apache 2.0 License with Commons Clause

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,10 @@ go test -cover ./...   # with coverage
 - Provider base URLs and timeouts come from `providers.json`, not env vars — check that file first when debugging connectivity.
 - Ollama-compatible endpoints intentionally advertise a single model named `PiPiMink v1` to clients, regardless of what models are loaded.
 
+## License
+
+Apache 2.0 with Commons Clause. See `LICENSE` for details. Repository: `github.com/Izzetee/PiPiMink`.
+
 ## What NOT to assume
 
 - PiPiMink does not optimize for cost. Do not add cost-related routing logic unless explicitly asked.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9,12 +9,38 @@ const docTemplate = `{
     "info": {
         "description": "{{escape .Description}}",
         "title": "{{.Title}}",
-        "contact": {},
+        "contact": {
+            "name": "API Support",
+            "url": "https://github.com/Izzetee/PiPiMink"
+        },
+        "license": {
+            "name": "Apache 2.0 with Commons Clause"
+        },
         "version": "{{.Version}}"
     },
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin": {
+            "get": {
+                "description": "Serves the admin web interface for model discovery, tagging, and benchmarking.",
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Admin UI",
+                "responses": {
+                    "200": {
+                        "description": "HTML page",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/benchmarks/leaderboard": {
             "get": {
                 "description": "Returns all models with benchmark scores, sorted by average score descending. Optional ?category filter.",
@@ -174,6 +200,106 @@ const docTemplate = `{
                 }
             }
         },
+        "/models/discover": {
+            "post": {
+                "description": "Queries each configured provider for its model list and registers any new models (no tagging).",
+                "tags": [
+                    "models",
+                    "admin"
+                ],
+                "summary": "Discover models from all providers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin API Key",
+                        "name": "X-API-Key",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/models/tag": {
+            "post": {
+                "description": "Runs the capability self-assessment (interview) for each supplied model and persists the tags.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "models",
+                    "admin"
+                ],
+                "summary": "Tag selected models",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Admin API Key",
+                        "name": "X-API-Key",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "List of models to tag: {\\",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/models/update": {
             "post": {
                 "description": "Triggers an update of model information from all configured sources",
@@ -251,6 +377,74 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Model not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/models/{name}/enable": {
+            "patch": {
+                "description": "Sets the enabled flag for a model. Requires admin API key.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "models",
+                    "admin"
+                ],
+                "summary": "Enable or disable a model",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Admin API Key",
+                        "name": "X-API-Key",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "{\\",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -370,12 +564,12 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "",
-	Host:             "",
-	BasePath:         "",
+	Version:          "1.0",
+	Host:             "localhost:8080",
+	BasePath:         "/",
 	Schemes:          []string{},
-	Title:            "",
-	Description:      "",
+	Title:            "PiPiMink API",
+	Description:      "An intelligent router for AI language model requests",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,358 +1,557 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "contact": {}
-    },
-    "paths": {
-        "/benchmarks/leaderboard": {
-            "get": {
-                "description": "Returns all models with benchmark scores, sorted by average score descending. Optional ?category filter.",
-                "tags": [
-                    "models"
-                ],
-                "summary": "Benchmark leaderboard",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Filter by category",
-                        "name": "category",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
+  "basePath": "/",
+  "definitions": {
+    "models.ChatRequest": {
+      "properties": {
+        "message": {
+          "type": "string"
         },
-        "/chat": {
-            "post": {
-                "description": "Routes the chat request to the most appropriate AI model based on message content",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "chat"
-                ],
-                "summary": "Process a chat request",
-                "parameters": [
-                    {
-                        "description": "Chat request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.ChatRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.ChatResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/models": {
-            "get": {
-                "description": "Returns a list of all available models",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "models"
-                ],
-                "summary": "List available models",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
-        "/models/benchmark": {
-            "post": {
-                "description": "Runs capability benchmarks against enabled models. Optional query params: model, category.",
-                "tags": [
-                    "models",
-                    "admin"
-                ],
-                "summary": "Run model benchmarks",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Admin API Key",
-                        "name": "X-API-Key",
-                        "in": "header",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Run only for this model name",
-                        "name": "model",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Run only tasks in this category (coding|reasoning|instruction-following|creative-writing|summarization|factual-qa)",
-                        "name": "category",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "description": "Accepted",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "503": {
-                        "description": "Benchmarks disabled",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/models/update": {
-            "post": {
-                "description": "Triggers an update of model information from all configured sources",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "models",
-                    "admin"
-                ],
-                "summary": "Update model information",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Admin API Key",
-                        "name": "X-API-Key",
-                        "in": "header",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/models/{name}/benchmarks": {
-            "get": {
-                "description": "Returns average benchmark scores per category for the specified model.",
-                "tags": [
-                    "models"
-                ],
-                "summary": "Get model benchmark scores",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Model name",
-                        "name": "name",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Provider source (required when multiple providers have the same model name)",
-                        "name": "source",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "404": {
-                        "description": "Model not found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/chat/completions": {
-            "post": {
-                "description": "OpenAI-compatible endpoint for chat completions",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "openai",
-                    "chat"
-                ],
-                "summary": "OpenAI-compatible chat completions",
-                "parameters": [
-                    {
-                        "description": "OpenAI-compatible chat request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "400": {
-                        "description": "Bad request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/v1/models": {
-            "get": {
-                "description": "OpenAI-compatible endpoint for listing available models",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "openai",
-                    "models"
-                ],
-                "summary": "OpenAI-compatible models listing",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
+        "messages": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "type": "array"
         }
+      },
+      "type": "object"
     },
-    "definitions": {
-        "models.ChatRequest": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "messages": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": true
-                    }
-                }
-            }
+    "models.ChatResponse": {
+      "properties": {
+        "model": {
+          "type": "string"
         },
-        "models.ChatResponse": {
-            "type": "object",
-            "properties": {
-                "model": {
-                    "type": "string"
-                },
-                "response": {
-                    "type": "string"
-                }
-            }
+        "response": {
+          "type": "string"
         }
+      },
+      "type": "object"
     }
+  },
+  "host": "localhost:8080",
+  "info": {
+    "contact": {
+      "name": "API Support",
+      "url": "https://github.com/Izzetee/PiPiMink"
+    },
+    "description": "An intelligent router for AI language model requests",
+    "license": {
+      "name": "Apache 2.0 with Commons Clause"
+    },
+    "title": "PiPiMink API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/admin": {
+      "get": {
+        "description": "Serves the admin web interface for model discovery, tagging, and benchmarking.",
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "HTML page",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "summary": "Admin UI",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
+    "/benchmarks/leaderboard": {
+      "get": {
+        "description": "Returns all models with benchmark scores, sorted by average score descending. Optional ?category filter.",
+        "parameters": [
+          {
+            "description": "Filter by category",
+            "in": "query",
+            "name": "category",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Benchmark leaderboard",
+        "tags": [
+          "models"
+        ]
+      }
+    },
+    "/chat": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Routes the chat request to the most appropriate AI model based on message content",
+        "parameters": [
+          {
+            "description": "Chat request",
+            "in": "body",
+            "name": "request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/models.ChatRequest"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/models.ChatResponse"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Process a chat request",
+        "tags": [
+          "chat"
+        ]
+      }
+    },
+    "/models": {
+      "get": {
+        "description": "Returns a list of all available models",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "summary": "List available models",
+        "tags": [
+          "models"
+        ]
+      }
+    },
+    "/models/{name}/benchmarks": {
+      "get": {
+        "description": "Returns average benchmark scores per category for the specified model.",
+        "parameters": [
+          {
+            "description": "Model name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Provider source (required when multiple providers have the same model name)",
+            "in": "query",
+            "name": "source",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "404": {
+            "description": "Model not found",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Get model benchmark scores",
+        "tags": [
+          "models"
+        ]
+      }
+    },
+    "/models/{name}/enable": {
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Sets the enabled flag for a model. Requires admin API key.",
+        "parameters": [
+          {
+            "description": "Model name",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Admin API Key",
+            "in": "header",
+            "name": "X-API-Key",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "{\\",
+            "in": "body",
+            "name": "request",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Enable or disable a model",
+        "tags": [
+          "models",
+          "admin"
+        ]
+      }
+    },
+    "/models/benchmark": {
+      "post": {
+        "description": "Runs capability benchmarks against enabled models. Optional query params: model, category.",
+        "parameters": [
+          {
+            "description": "Admin API Key",
+            "in": "header",
+            "name": "X-API-Key",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Run only for this model name",
+            "in": "query",
+            "name": "model",
+            "type": "string"
+          },
+          {
+            "description": "Run only tasks in this category (coding|reasoning|instruction-following|creative-writing|summarization|factual-qa)",
+            "in": "query",
+            "name": "category",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "503": {
+            "description": "Benchmarks disabled",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Run model benchmarks",
+        "tags": [
+          "models",
+          "admin"
+        ]
+      }
+    },
+    "/models/discover": {
+      "post": {
+        "description": "Queries each configured provider for its model list and registers any new models (no tagging).",
+        "parameters": [
+          {
+            "description": "Admin API Key",
+            "in": "header",
+            "name": "X-API-Key",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Discover models from all providers",
+        "tags": [
+          "models",
+          "admin"
+        ]
+      }
+    },
+    "/models/tag": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Runs the capability self-assessment (interview) for each supplied model and persists the tags.",
+        "parameters": [
+          {
+            "description": "Admin API Key",
+            "in": "header",
+            "name": "X-API-Key",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "List of models to tag: {\\",
+            "in": "body",
+            "name": "request",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Tag selected models",
+        "tags": [
+          "models",
+          "admin"
+        ]
+      }
+    },
+    "/models/update": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "Triggers an update of model information from all configured sources",
+        "parameters": [
+          {
+            "description": "Admin API Key",
+            "in": "header",
+            "name": "X-API-Key",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "Update model information",
+        "tags": [
+          "models",
+          "admin"
+        ]
+      }
+    },
+    "/v1/chat/completions": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "description": "OpenAI-compatible endpoint for chat completions",
+        "parameters": [
+          {
+            "description": "OpenAI-compatible chat request",
+            "in": "body",
+            "name": "request",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          }
+        },
+        "summary": "OpenAI-compatible chat completions",
+        "tags": [
+          "openai",
+          "chat"
+        ]
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "description": "OpenAI-compatible endpoint for listing available models",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "additionalProperties": true,
+              "type": "object"
+            }
+          }
+        },
+        "summary": "OpenAI-compatible models listing",
+        "tags": [
+          "openai",
+          "models"
+        ]
+      }
+    }
+  },
+  "swagger": "2.0"
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,3 +1,4 @@
+basePath: /
 definitions:
   models.ChatRequest:
     properties:
@@ -16,9 +17,31 @@ definitions:
       response:
         type: string
     type: object
+host: localhost:8080
 info:
-  contact: {}
+  contact:
+    name: API Support
+    url: https://github.com/Izzetee/PiPiMink
+  description: An intelligent router for AI language model requests
+  license:
+    name: Apache 2.0 with Commons Clause
+  title: PiPiMink API
+  version: "1.0"
 paths:
+  /admin:
+    get:
+      description: Serves the admin web interface for model discovery, tagging, and
+        benchmarking.
+      produces:
+      - text/html
+      responses:
+        "200":
+          description: HTML page
+          schema:
+            type: string
+      summary: Admin UI
+      tags:
+      - admin
   /benchmarks/leaderboard:
     get:
       description: Returns all models with benchmark scores, sorted by average score
@@ -116,6 +139,52 @@ paths:
       summary: Get model benchmark scores
       tags:
       - models
+  /models/{name}/enable:
+    patch:
+      consumes:
+      - application/json
+      description: Sets the enabled flag for a model. Requires admin API key.
+      parameters:
+      - description: Model name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Admin API Key
+        in: header
+        name: X-API-Key
+        required: true
+        type: string
+      - description: '{\'
+        in: body
+        name: request
+        required: true
+        schema:
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Enable or disable a model
+      tags:
+      - models
+      - admin
   /models/benchmark:
     post:
       description: 'Runs capability benchmarks against enabled models. Optional query
@@ -154,6 +223,75 @@ paths:
               type: string
             type: object
       summary: Run model benchmarks
+      tags:
+      - models
+      - admin
+  /models/discover:
+    post:
+      description: Queries each configured provider for its model list and registers
+        any new models (no tagging).
+      parameters:
+      - description: Admin API Key
+        in: header
+        name: X-API-Key
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Discover models from all providers
+      tags:
+      - models
+      - admin
+  /models/tag:
+    post:
+      consumes:
+      - application/json
+      description: Runs the capability self-assessment (interview) for each supplied
+        model and persists the tags.
+      parameters:
+      - description: Admin API Key
+        in: header
+        name: X-API-Key
+        required: true
+        type: string
+      - description: 'List of models to tag: {\'
+        in: body
+        name: request
+        required: true
+        schema:
+          type: object
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Tag selected models
       tags:
       - models
       - admin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module PiPiMink
 
-go 1.25.0
+go 1.25.3
 
 // Primary dependencies
 require (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,7 +238,7 @@ func loadProviders(dir string) []ProviderConfig {
 		if p.APIKeyEnv != "" {
 			p.APIKey = os.Getenv(p.APIKeyEnv)
 			if p.APIKey == "" {
-				log.Printf("Warning: provider %q references env var %q which is not set", p.Name, p.APIKeyEnv)
+				log.Printf("Warning: provider %q: API key not set (check env configuration)", p.Name)
 			}
 		}
 
@@ -248,7 +248,7 @@ func loadProviders(dir string) []ProviderConfig {
 			if mc.APIKeyEnv != "" {
 				mc.APIKey = os.Getenv(mc.APIKeyEnv)
 				if mc.APIKey == "" {
-					log.Printf("Warning: provider %q model %q references env var %q which is not set", p.Name, mc.Name, mc.APIKeyEnv)
+					log.Printf("Warning: provider %q model %q: API key not set (check env configuration)", p.Name, mc.Name)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Remove env var names from API key log messages to resolve CodeQL cleartext-logging security alert (`internal/config/config.go`)
- Correct license reference in CHANGELOG.md (MIT → Apache 2.0 + Commons Clause)
- Add License section to CLAUDE.md
- Bump `go.mod` from Go 1.25.0 to 1.25.3 (stdlib CVE fixes)
- Regenerate Swagger docs

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short ./...` passes
- [x] CodeQL re-scan shows no cleartext-logging alert on config.go
- [x] Verify Swagger UI renders correctly at `/swagger/index.html`