### PR TITLE
Switch to Apache License 2.0, add trademark policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,4 +99,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `providers.json` configuration with `providers.example.json` template
 - Docker Compose stack (`docker-compose.yml`, `docker-compose-db.yml`, `docker-compose-app.yml`)
 - Helper scripts in `scripts/`: `start-stack.sh`, `update_models.sh`, `test_chat_request.sh`, `generate-swagger.sh`
-- Apache 2.0 License with Commons Clause
+- Apache License 2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ go test -cover ./...   # with coverage
 
 ## License
 
-Apache 2.0 with Commons Clause. See `LICENSE` for details. Repository: `github.com/Izzetee/PiPiMink`.
+Apache License 2.0. See `LICENSE` for the full text, `NOTICE` for attribution, and `TRADEMARKS.md` for the trademark policy. Repository: `github.com/Izzetee/PiPiMink`.
 
 ## What NOT to assume
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thank you for your interest in contributing! This document explains how to get s
 
 ## Table of Contents
 
+- [License](#license)
 - [AI-Assisted Development](#ai-assisted-development)
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
@@ -13,6 +14,16 @@ Thank you for your interest in contributing! This document explains how to get s
 - [Code Style](#code-style)
 - [Tests](#tests)
 - [Swagger / OpenAPI Docs](#swagger--openapi-docs)
+
+---
+
+## License
+
+By intentionally submitting a contribution for inclusion in PiPiMink — whether via pull request, patch, or any other mechanism — you agree that your contribution will be licensed under the [Apache License 2.0](LICENSE), the same license that covers the project, unless you explicitly state otherwise.
+
+You retain copyright to your own contributions. No separate Contributor License Agreement (CLA) is required.
+
+> **Optional note for future consideration:** The project may adopt [Developer Certificate of Origin (DCO)](https://developercertificate.org/) sign-off (`git commit -s`) in the future to formalize contribution provenance. This is not currently required.
 
 ---
 
@@ -41,7 +52,7 @@ This project was built with the help of AI coding tools (Claude Code, GitHub Cop
 
 **Prerequisites:**
 
-- Go 1.22+
+- Go 1.25+
 - Docker & Docker Compose
 - A PostgreSQL instance (or use the provided compose stack)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,46 +1,201 @@
-Apache License 2.0 with Commons Clause
 
-Copyright (c) 2026 PiPiMink contributors
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Licensed under the Apache License, Version 2.0 (the "License") with the
-Commons Clause restriction set forth below. You may not use this file except
-in compliance with the License. You may obtain a copy of the Apache License
-at:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-    https://www.apache.org/licenses/LICENSE-2.0
+   1. Definitions.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
---- Commons Clause Restriction ---
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-"Commons Clause" License Condition v1.0
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-The Software is provided to you by the Licensor under the License, as
-defined below, subject to the following condition.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-Without limiting other conditions in the License, the grant of rights under
-the License will not include, and the License does not grant to you, the
-right to Sell the Software.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-For purposes of the foregoing, "Sell" means practicing any or all of the
-rights granted to you under the License to provide to third parties, for a
-fee or other consideration (including without limitation fees for hosting or
-consulting/support services related to the Software), a product or service
-whose value derives, entirely or substantially, from the functionality of
-the Software. Any license notice or attribution required by the License must
-also include this Commons Clause License Condition notice.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-Software: PiPiMink
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-License: Apache 2.0
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-Licensor: PiPiMink contributors
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-For commercial licensing inquiries (including reselling or offering PiPiMink
-as a managed service), please contact the project maintainers via:
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
 
-    https://github.com/Izzetee/PiPiMink/issues
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with the Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an approval
+      for your license configuration from the ASF (Apache Software
+      Foundation) to use the Apache License for your project.
+
+   Copyright 2026 PiPiMink contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+PiPiMink
+Copyright 2026 PiPiMink contributors
+
+This product includes software developed by the PiPiMink project
+(https://github.com/Izzetee/PiPiMink).
+
+Licensed under the Apache License, Version 2.0.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/Izzetee/PiPiMink/actions/workflows/ci.yml"><img src="https://github.com/Izzetee/PiPiMink/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Izzetee/PiPiMink/actions/workflows/security.yml"><img src="https://github.com/Izzetee/PiPiMink/actions/workflows/security.yml/badge.svg" alt="Security"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0%20%2B%20Commons%20Clause-blue" alt="License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
 </p>
 
 PiPiMink is a Go service that routes each prompt to the LLM most likely to produce the best response — **for you specifically**.
@@ -175,4 +175,8 @@ This project was developed with the assistance of AI coding tools. Contributions
 
 ## License
 
-Apache 2.0 with [Commons Clause](LICENSE). Free to use, modify, and self-host. Commercial reselling requires prior permission — see the [LICENSE](LICENSE) for details.
+PiPiMink is open source software licensed under the [Apache License 2.0](LICENSE). You are free to use, modify, and redistribute the code under the terms of that license.
+
+The project name "PiPiMink", logo, and official branding are governed by a separate [trademark policy](TRADEMARKS.md) and are not covered by the Apache-2.0 license.
+
+See also: [NOTICE](NOTICE) | [CONTRIBUTING.md](CONTRIBUTING.md) | [TRADEMARKS.md](TRADEMARKS.md)

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,50 @@
+# Trademark Policy
+
+## Overview
+
+The PiPiMink source code is licensed under the [Apache License 2.0](LICENSE), which permits free use, modification, and redistribution of the code. This trademark policy covers a separate topic: the project's **name, logo, and official branding**.
+
+The Apache-2.0 license does not grant rights to use the PiPiMink trademarks. This policy explains what is allowed and what requires permission.
+
+## What you can do without asking
+
+You do not need permission to:
+
+- **Refer to PiPiMink by name** in truthful, descriptive ways — for example, in blog posts, talks, documentation, or comparisons.
+- **State compatibility** — for example, "works with PiPiMink" or "compatible with the PiPiMink API".
+- **Describe a fork or derivative** — for example, "based on PiPiMink" or "derived from PiPiMink".
+- **Link to the official repository** or cite the project in academic or technical writing.
+
+These uses are welcome and encouraged.
+
+## What requires prior written permission
+
+You need permission from the maintainer before:
+
+- **Using the PiPiMink logo** as if it were your own product branding, or in a way that implies your project is the official PiPiMink.
+- **Naming a fork, product, or service** in a way that is confusingly similar to "PiPiMink" — for example, "PiPiMink Pro", "PiPiMink Cloud", or "Official PiPiMink".
+- **Claiming endorsement, affiliation, certification, or sponsorship** by the PiPiMink project or its maintainers when none exists.
+- **Using PiPiMink branding in commercial marketing** in a way that could mislead people into thinking your product or service is the official PiPiMink or is officially endorsed by the project.
+
+When in doubt, ask first.
+
+## Naming forks and derivatives
+
+If you fork PiPiMink and distribute your modified version, please choose a distinct name that makes it clear your project is separate from the official PiPiMink. You are welcome to say that your project is "based on PiPiMink" or "derived from PiPiMink".
+
+## The logo and visual assets
+
+The PiPiMink logo and visual assets in the `assets/` directory are not covered by the Apache-2.0 code license. They may not be used to represent a different project, product, or service without permission.
+
+## Permission requests
+
+If you would like permission for any use not covered above, please reach out:
+
+- **GitHub Issues:** <https://github.com/Izzetee/PiPiMink/issues>
+- **Email:** [INSERT CONTACT EMAIL]
+
+We are happy to discuss and generally supportive of community use — just ask.
+
+## Scope
+
+This policy applies to the name "PiPiMink", the project logo, and any official branding materials. It does not restrict any rights granted by the [Apache License 2.0](LICENSE) over the source code itself.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -14,7 +14,8 @@ const docTemplate = `{
             "url": "https://github.com/Izzetee/PiPiMink"
         },
         "license": {
-            "name": "Apache 2.0 with Commons Clause"
+            "name": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
         },
         "version": "{{.Version}}"
     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -36,7 +36,8 @@
     },
     "description": "An intelligent router for AI language model requests",
     "license": {
-      "name": "Apache 2.0 with Commons Clause"
+      "name": "Apache-2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
     "title": "PiPiMink API",
     "version": "1.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -24,7 +24,8 @@ info:
     url: https://github.com/Izzetee/PiPiMink
   description: An intelligent router for AI language model requests
   license:
-    name: Apache 2.0 with Commons Clause
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
   title: PiPiMink API
   version: "1.0"
 paths:

--- a/main.go
+++ b/main.go
@@ -17,7 +17,8 @@ import (
 // @description An intelligent router for AI language model requests
 // @contact.name API Support
 // @contact.url https://github.com/Izzetee/PiPiMink
-// @license.name Apache 2.0 with Commons Clause
+// @license.name Apache-2.0
+// @license.url https://www.apache.org/licenses/LICENSE-2.0
 // @host localhost:8080
 // @BasePath /
 


### PR DESCRIPTION
## Summary
- Replace Apache 2.0 + Commons Clause with the **standard, unmodified Apache License 2.0**
- Remove all anti-resale / anti-commercial restrictions from the code license
- Add **TRADEMARKS.md** to protect the project name, logo, and branding separately
- Add **NOTICE** file (standard Apache-2.0 attribution)
- Update **CONTRIBUTING.md** with Apache-2.0 contribution terms (no CLA required)
- Update license references across README, CLAUDE.md, CHANGELOG.md, main.go, and Swagger docs

## New licensing model
| Scope | Governed by |
|-------|------------|
| Source code | Apache License 2.0 (use, modify, redistribute freely) |
| Project name, logo, branding | Trademark policy (TRADEMARKS.md) |
| Contributions | Apache-2.0 by default, no CLA |

## Old restrictions removed
- "Commons Clause" anti-resale restriction
- "Commercial reselling requires prior permission" wording
- All "source-available" / "non-commercial" framing

## Placeholders needing maintainer input
- `TRADEMARKS.md`: `[INSERT CONTACT EMAIL]` for trademark permission requests

## Test plan
- [x] `go build ./...` passes
- [x] No remaining "Commons Clause" or anti-resale references (`grep -ri "commons clause\|resale\|resell\|non-commercial" *.md *.go`)
- [x] LICENSE badge on README renders correctly
- [x] Swagger UI shows "Apache-2.0" license
- [x] TRADEMARKS.md, NOTICE render correctly on GitHub