### PR TITLE
Fix 404 for model names containing slashes

### DIFF
--- a/cmd/server/handlers.go
+++ b/cmd/server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -602,7 +603,7 @@ func (s *Server) handleRunBenchmarks(w http.ResponseWriter, r *http.Request) {
 // @Router /models/{name}/benchmarks [get]
 func (s *Server) handleGetModelBenchmarks(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	modelName := vars["name"]
+	modelName, _ := url.PathUnescape(vars["name"])
 
 	// Resolve source: prefer query param, fall back to model collection.
 	source := r.URL.Query().Get("source")
@@ -737,7 +738,7 @@ func (s *Server) handleSetModelEnabled(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	name := mux.Vars(r)["name"]
+	name, _ := url.PathUnescape(mux.Vars(r)["name"])
 	var body struct {
 		Source  string `json:"source"`
 		Enabled bool   `json:"enabled"`

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -38,7 +38,7 @@ func NewServer(cfg *config.Config, db DatabaseInterface, llmClient LLMInterface)
 		config:          cfg,
 		db:              db,
 		llmClient:       llmClient,
-		router:          mux.NewRouter(),
+		router:          mux.NewRouter().UseEncodedPath(),
 		modelCollection: models.NewModelCollection(),
 		httpMetrics:     newHTTPMetrics(),
 	}


### PR DESCRIPTION
## Summary
- Model names like `google/gemma-3-4b` (common with LM Studio / HuggingFace naming) caused 404 errors on the enable/disable toggle and benchmark endpoints
- The frontend correctly encodes the slash as `%2F`, but gorilla/mux decoded it back to `/` before matching, breaking the route

## Fix
- Enable `UseEncodedPath()` on the mux router so `%2F` stays encoded during route matching
- Add `url.PathUnescape()` in `handleSetModelEnabled` and `handleGetModelBenchmarks` to decode the name for DB lookups

## Test plan
- [x] `go test -short ./...` passes
- [x] Toggle enable/disable on a model with `/` in the name (e.g. `google/gemma-3-4b` from LM Studio)
- [x] View benchmark results for a model with `/` in the name
- [x] Models without slashes still work as before
