### PR TITLE
Fix judge and selection provider per-model overrides

### DIFF
--- a/internal/benchmark/scorer.go
+++ b/internal/benchmark/scorer.go
@@ -8,25 +8,25 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"time"
+
+	"PiPiMink/internal/config"
 )
 
 // Scorer evaluates model responses. Deterministic and format-check tasks are scored locally;
 // LLM-judge tasks are sent to a configurable judge model.
 type Scorer struct {
-	judgeBaseURL string
-	judgeAPIKey  string
-	judgeModel   string
-	httpClient   *http.Client
+	judgeProvider config.ProviderConfig // resolved provider config (with per-model overrides applied)
+	judgeModel    string
+	httpClient    *http.Client
 }
 
 // NewScorer creates a scorer backed by the given judge model endpoint.
-func NewScorer(judgeBaseURL, judgeAPIKey, judgeModel string, timeout time.Duration) *Scorer {
+// The provider config should already have per-model overrides applied via ForModel().
+func NewScorer(judgeProvider config.ProviderConfig, judgeModel string) *Scorer {
 	return &Scorer{
-		judgeBaseURL: judgeBaseURL,
-		judgeAPIKey:  judgeAPIKey,
-		judgeModel:   judgeModel,
-		httpClient:   &http.Client{Timeout: timeout},
+		judgeProvider: judgeProvider,
+		judgeModel:    judgeModel,
+		httpClient:    &http.Client{Timeout: judgeProvider.Timeout},
 	}
 }
 
@@ -61,7 +61,7 @@ func (s *Scorer) scoreDeterministic(expected, response string) float64 {
 // scale. The final score is the average of all criterion scores, normalised to [0.0, 1.0].
 // Returns 0.0 on any error.
 func (s *Scorer) scoreLLMJudge(ctx context.Context, task Task, response string) float64 {
-	if s.judgeBaseURL == "" || s.judgeModel == "" {
+	if s.judgeProvider.BaseURL == "" || s.judgeModel == "" {
 		log.Printf("benchmark: judge not configured, skipping LLM judge for task %s", task.ID)
 		return 0.0
 	}
@@ -92,30 +92,38 @@ func (s *Scorer) scoreLLMJudge(ctx context.Context, task Task, response string) 
 		task.Prompt, response, criteriaText,
 	)
 
-	payload := map[string]interface{}{
-		"model":       s.judgeModel,
-		"temperature": 0.0,
-		"messages": []map[string]string{
-			{"role": "system", "content": systemMsg},
-			{"role": "user", "content": userMsg},
-		},
-	}
+	var body []byte
+	var url string
+	var err error
 
-	body, err := json.Marshal(payload)
+	switch s.judgeProvider.Type {
+	case config.ProviderTypeAnthropic:
+		body, url, err = s.buildAnthropicRequest(systemMsg, userMsg)
+	default:
+		body, url, err = s.buildOpenAIRequest(systemMsg, userMsg)
+	}
 	if err != nil {
 		log.Printf("benchmark: judge marshal error for task %s: %v", task.ID, err)
 		return 0.0
 	}
 
-	url := s.judgeBaseURL + "/v1/chat/completions"
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		log.Printf("benchmark: judge request creation error for task %s: %v", task.ID, err)
 		return 0.0
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if s.judgeAPIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+s.judgeAPIKey)
+
+	switch s.judgeProvider.Type {
+	case config.ProviderTypeAnthropic:
+		if s.judgeProvider.APIKey != "" {
+			req.Header.Set("x-api-key", s.judgeProvider.APIKey)
+		}
+		req.Header.Set("anthropic-version", "2023-06-01")
+	default:
+		if s.judgeProvider.APIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+s.judgeProvider.APIKey)
+		}
 	}
 
 	resp, err := s.httpClient.Do(req)
@@ -131,20 +139,14 @@ func (s *Scorer) scoreLLMJudge(ctx context.Context, task Task, response string) 
 		return 0.0
 	}
 
-	// Extract the content from the OpenAI-format response.
-	var apiResp struct {
-		Choices []struct {
-			Message struct {
-				Content string `json:"content"`
-			} `json:"message"`
-		} `json:"choices"`
-	}
-	if err := json.Unmarshal(buf.Bytes(), &apiResp); err != nil || len(apiResp.Choices) == 0 {
-		log.Printf("benchmark: judge response parse error for task %s: %v (body: %s)", task.ID, err, buf.String())
+	log.Printf("benchmark: judge response status=%d body=%s", resp.StatusCode, buf.String())
+
+	// Extract text content from the response based on provider type.
+	content, err := s.extractJudgeContent(buf.Bytes())
+	if err != nil {
+		log.Printf("benchmark: judge response parse error for task %s: %v", task.ID, err)
 		return 0.0
 	}
-
-	content := apiResp.Choices[0].Message.Content
 
 	// Extract the JSON object from the content (the judge may add surrounding text).
 	start := strings.Index(content, "{")
@@ -180,6 +182,85 @@ func (s *Scorer) scoreLLMJudge(ctx context.Context, task Task, response string) 
 	normalised := (sum / float64(len(judgeResult.Scores))) / 10.0
 	log.Printf("benchmark: judge scores %v (avg=%.2f) for task %s — %s", judgeResult.Scores, normalised, task.ID, judgeResult.Reason)
 	return normalised
+}
+
+// buildOpenAIRequest builds the JSON payload and URL for an OpenAI-compatible judge request.
+func (s *Scorer) buildOpenAIRequest(systemMsg, userMsg string) ([]byte, string, error) {
+	payload := map[string]interface{}{
+		"model":       s.judgeModel,
+		"temperature": 0.0,
+		"messages": []map[string]string{
+			{"role": "system", "content": systemMsg},
+			{"role": "user", "content": userMsg},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, s.judgeProvider.ChatCompletionsURL(), nil
+}
+
+// buildAnthropicRequest builds the JSON payload and URL for an Anthropic Messages API judge request.
+func (s *Scorer) buildAnthropicRequest(systemMsg, userMsg string) ([]byte, string, error) {
+	payload := map[string]interface{}{
+		"model":      s.judgeModel,
+		"max_tokens": 4096,
+		"system":     systemMsg,
+		"messages": []map[string]string{
+			{"role": "user", "content": userMsg},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, s.judgeProvider.BaseURL + "/v1/messages", nil
+}
+
+// extractJudgeContent extracts the text content from a judge API response,
+// handling both OpenAI and Anthropic response formats.
+func (s *Scorer) extractJudgeContent(body []byte) (string, error) {
+	switch s.judgeProvider.Type {
+	case config.ProviderTypeAnthropic:
+		return extractAnthropicContent(body)
+	default:
+		return extractOpenAIContent(body)
+	}
+}
+
+// extractOpenAIContent extracts text from an OpenAI-compatible chat completions response.
+func extractOpenAIContent(body []byte) (string, error) {
+	var apiResp struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return "", fmt.Errorf("error decoding OpenAI response: %w", err)
+	}
+	if len(apiResp.Choices) == 0 {
+		return "", fmt.Errorf("missing or empty choices in OpenAI response")
+	}
+	return apiResp.Choices[0].Message.Content, nil
+}
+
+// extractAnthropicContent extracts text from an Anthropic Messages API response.
+func extractAnthropicContent(body []byte) (string, error) {
+	var result struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("error decoding Anthropic response: %w", err)
+	}
+	if len(result.Content) == 0 {
+		return "", fmt.Errorf("missing or empty content in Anthropic response")
+	}
+	return result.Content[0].Text, nil
 }
 
 func min(a, b float64) float64 {

--- a/internal/benchmark/suite.go
+++ b/internal/benchmark/suite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"sync"
-	"time"
 
 	"PiPiMink/internal/config"
 	"PiPiMink/internal/models"
@@ -34,21 +33,22 @@ func (s *Suite) WithTasks(tasks []Task) *Suite {
 }
 
 // NewSuite creates a Suite wired to the given database, config, and chat function.
-// judgeBaseURL/judgeAPIKey/judgeModel define the model used to score LLM-judge tasks.
-// If judgeModel is empty the suite falls back to the configured MODEL_SELECTION_MODEL.
+// The judge provider and model are resolved from BENCHMARK_JUDGE_PROVIDER/MODEL config,
+// falling back to MODEL_SELECTION_PROVIDER/MODEL. Per-model overrides are applied.
 func NewSuite(db DB, cfg *config.Config, chatFn ChatFunc) *Suite {
-	judgeBaseURL, judgeAPIKey, judgeModel := resolveJudge(cfg)
+	judgeProvider, judgeModel := resolveJudge(cfg)
 	return &Suite{
 		db:     db,
 		cfg:    cfg,
-		scorer: NewScorer(judgeBaseURL, judgeAPIKey, judgeModel, 2*time.Minute),
+		scorer: NewScorer(judgeProvider, judgeModel),
 		chatFn: chatFn,
 	}
 }
 
-// resolveJudge returns the base URL, API key, and model name for the LLM judge.
+// resolveJudge returns the resolved provider config and model name for the LLM judge.
 // It uses BENCHMARK_JUDGE_PROVIDER/MODEL if set, otherwise falls back to the selection provider.
-func resolveJudge(cfg *config.Config) (baseURL, apiKey, model string) {
+// Per-model overrides (base_url, api_key, type, chat_path) are applied via ForModel().
+func resolveJudge(cfg *config.Config) (config.ProviderConfig, string) {
 	judgeProviderName := cfg.BenchmarkJudgeProvider
 	if judgeProviderName == "" {
 		judgeProviderName = cfg.ModelSelectionProvider
@@ -60,10 +60,10 @@ func resolveJudge(cfg *config.Config) (baseURL, apiKey, model string) {
 
 	for _, p := range cfg.Providers {
 		if p.Name == judgeProviderName {
-			return p.BaseURL, p.APIKey, judgeModel
+			return p.ForModel(judgeModel), judgeModel
 		}
 	}
-	return "", "", judgeModel
+	return config.ProviderConfig{}, judgeModel
 }
 
 // Run executes benchmarks for all provided enabled models.

--- a/internal/llm/model_selection.go
+++ b/internal/llm/model_selection.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"PiPiMink/internal/config"
 	"PiPiMink/internal/models"
 )
 
@@ -30,14 +31,14 @@ func (c *Client) fallbackModel() string {
 	return c.selectionModel()
 }
 
-// selectionProviderURL returns the base URL and API key for the provider used
-// to make routing decisions (the meta-router).
-func (c *Client) selectionProviderCredentials() (baseURL, apiKey string) {
-	if p, ok := c.selectionProvider(); ok {
-		return p.BaseURL, p.APIKey
+// resolvedSelectionProvider returns the ProviderConfig for the meta-router
+// with per-model overrides applied (base_url, api_key, type, chat_path).
+func (c *Client) resolvedSelectionProvider() (config.ProviderConfig, bool) {
+	p, ok := c.selectionProvider()
+	if !ok {
+		return p, false
 	}
-	// Hard fallback — should not normally be reached.
-	return "https://api.openai.com", ""
+	return p.ForModel(c.selectionModel()), true
 }
 
 // DecideModelBasedOnCapabilities analyzes a message and determines the best model to use
@@ -75,17 +76,12 @@ func (c *Client) DecideModelBasedOnCapabilities(message string, availableModels 
 	log.Printf("Starting model decision process for message: %.100s...", message)
 	log.Printf("Available models count: %d", len(availableModels))
 
-	// Use the configured selection provider for routing decisions.
-	_, selAPIKey := c.selectionProviderCredentials()
-	selProvider, hasSP := c.selectionProvider()
-	var selTimeout = 2 * time.Minute
-	url := "https://api.openai.com/v1/chat/completions" // hard fallback, normally overridden below
-	if hasSP {
-		selTimeout = selProvider.Timeout
-		url = selProvider.ChatCompletionsURL()
+	// Use the configured selection provider for routing decisions (with per-model overrides).
+	selProvider, hasSP := c.resolvedSelectionProvider()
+	if !hasSP {
+		return "", fmt.Errorf("no selection provider configured")
 	}
-	apiKey := selAPIKey
-	client := &http.Client{Timeout: selTimeout}
+	client := &http.Client{Timeout: selProvider.Timeout}
 
 	// Prepare model capabilities information
 	hasBenchmarkScores := false
@@ -159,36 +155,58 @@ func (c *Client) DecideModelBasedOnCapabilities(message string, availableModels 
 	// Create the request payload with temperature=0 for consistent responses
 	selectionModel := c.selectionModel()
 	fallbackModel := c.fallbackModel()
-	payload := map[string]interface{}{
-		"model":       selectionModel,
-		"temperature": 0.0, // Set temperature to 0 for consistent responses
-		"messages": []map[string]string{
-			{
-				"role":    "system",
-				"content": systemMessage,
-			},
-			{
-				"role":    "user",
-				"content": message,
-			},
-		},
-	}
 
-	jsonPayload, err := json.Marshal(payload)
+	var jsonPayload []byte
+	var endpoint string
+
+	switch selProvider.Type {
+	case config.ProviderTypeAnthropic:
+		payload := map[string]interface{}{
+			"model":      selectionModel,
+			"max_tokens": 4096,
+			"system":     systemMessage,
+			"messages": []map[string]string{
+				{"role": "user", "content": message},
+			},
+		}
+		jsonPayload, err = json.Marshal(payload)
+		endpoint = selProvider.BaseURL + "/v1/messages"
+	default:
+		payload := map[string]interface{}{
+			"model":       selectionModel,
+			"temperature": 0.0,
+			"messages": []map[string]string{
+				{"role": "system", "content": systemMessage},
+				{"role": "user", "content": message},
+			},
+		}
+		jsonPayload, err = json.Marshal(payload)
+		endpoint = selProvider.ChatCompletionsURL()
+	}
 	if err != nil {
 		return "", fmt.Errorf("error marshalling payload: %w", err)
 	}
 
 	// Create and send the HTTP request
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonPayload))
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		return "", fmt.Errorf("error creating request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	switch selProvider.Type {
+	case config.ProviderTypeAnthropic:
+		if selProvider.APIKey != "" {
+			req.Header.Set("x-api-key", selProvider.APIKey)
+		}
+		req.Header.Set("anthropic-version", anthropicVersion)
+	default:
+		if selProvider.APIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+selProvider.APIKey)
+		}
+	}
 
-	log.Printf("Sending model selection request")
+	log.Printf("Sending model selection request to %s (type: %s)", endpoint, selProvider.Type)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error making request: %w", err)
@@ -206,43 +224,22 @@ func (c *Client) DecideModelBasedOnCapabilities(message string, availableModels 
 	responseStr := responseBody.String()
 	log.Printf("Raw API response: %s", responseStr)
 
-	// Parse the JSON response
-	var result map[string]interface{}
-	if err := json.Unmarshal(responseBody.Bytes(), &result); err != nil {
-		return "", fmt.Errorf("error decoding response JSON: %w", err)
+	// Extract text content from the response based on provider type.
+	var content string
+	switch selProvider.Type {
+	case config.ProviderTypeAnthropic:
+		content, err = extractAnthropicContent(responseBody.Bytes())
+		if err != nil {
+			return "", fmt.Errorf("error extracting content from Anthropic response: %w", err)
+		}
+	default:
+		content, err = extractOpenAISelectionContent(responseBody.Bytes())
+		if err != nil {
+			return "", err
+		}
 	}
 
-	// Extract model name from response with detailed error checking
-	choices, ok := result["choices"].([]interface{})
-	if !ok {
-		log.Printf("Error: 'choices' field is missing or not an array. Response keys: %v", getMapKeys(result))
-		return "", fmt.Errorf("error extracting choices from response: 'choices' field missing or invalid")
-	}
-
-	if len(choices) == 0 {
-		log.Printf("Error: 'choices' array is empty")
-		return "", fmt.Errorf("error extracting choices from response: 'choices' array is empty")
-	}
-
-	choice, ok := choices[0].(map[string]interface{})
-	if !ok {
-		log.Printf("Error: first choice is not an object. Type: %T", choices[0])
-		return "", fmt.Errorf("error extracting first choice from response")
-	}
-
-	messageObj, ok := choice["message"].(map[string]interface{})
-	if !ok {
-		log.Printf("Error: 'message' field missing or invalid in choice. Choice keys: %v", getMapKeys(choice))
-		return "", fmt.Errorf("error extracting message from response")
-	}
-
-	content, ok := messageObj["content"].(string)
-	if !ok {
-		log.Printf("Error: 'content' field missing or not a string in message. Message keys: %v", getMapKeys(messageObj))
-		return "", fmt.Errorf("error extracting content from message")
-	}
-
-	log.Printf("Extracted model name: '%s'", content)
+	log.Printf("Extracted model selection content: '%s'", content)
 
 	// Extract JSON from the response content
 	jsonStart := strings.Index(content, "{")
@@ -293,6 +290,42 @@ func (c *Client) DecideModelBasedOnCapabilities(message string, availableModels 
 	elapsedTime := time.Since(startTime)
 	log.Printf("Model selection with %s took %v to evaluate the prompt", selectionModel, elapsedTime)
 	return selectedModel, nil
+}
+
+// extractOpenAISelectionContent extracts the text content from an OpenAI-compatible
+// chat completions response, with detailed error logging for debugging.
+func extractOpenAISelectionContent(body []byte) (string, error) {
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("error decoding response JSON: %w", err)
+	}
+
+	choices, ok := result["choices"].([]interface{})
+	if !ok {
+		log.Printf("Error: 'choices' field is missing or not an array. Response keys: %v", getMapKeys(result))
+		return "", fmt.Errorf("error extracting choices from response: 'choices' field missing or invalid")
+	}
+	if len(choices) == 0 {
+		return "", fmt.Errorf("error extracting choices from response: 'choices' array is empty")
+	}
+
+	choice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("error extracting first choice from response")
+	}
+
+	messageObj, ok := choice["message"].(map[string]interface{})
+	if !ok {
+		log.Printf("Error: 'message' field missing or invalid in choice. Choice keys: %v", getMapKeys(choice))
+		return "", fmt.Errorf("error extracting message from response")
+	}
+
+	content, ok := messageObj["content"].(string)
+	if !ok {
+		log.Printf("Error: 'content' field missing or not a string in message. Message keys: %v", getMapKeys(messageObj))
+		return "", fmt.Errorf("error extracting content from message")
+	}
+	return content, nil
 }
 
 // DecideModel is a simpler model decision function that returns a default model.

--- a/internal/llm/model_selection_additional_test.go
+++ b/internal/llm/model_selection_additional_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,6 +49,118 @@ func TestDecideModelBasedOnCapabilitiesFallbackOnInvalidJSONContent(t *testing.T
 	selectedModel, err := client.DecideModelBasedOnCapabilities("hello", availableModels)
 	assert.Error(t, err)
 	assert.Equal(t, "gpt-4-turbo", selectedModel)
+}
+
+func TestDecideModelBasedOnCapabilitiesWithAnthropicProvider(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify Anthropic API format
+		assert.Equal(t, "/v1/messages", r.URL.Path)
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "test-anthropic-key", r.Header.Get("x-api-key"))
+		assert.Equal(t, "2023-06-01", r.Header.Get("anthropic-version"))
+		assert.Empty(t, r.Header.Get("Authorization"), "should not set Bearer auth for Anthropic")
+
+		// Verify payload is Anthropic format (system as top-level field, not in messages)
+		var payload map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, payload["system"], "system message should be top-level field")
+		assert.Equal(t, float64(4096), payload["max_tokens"])
+		msgs := payload["messages"].([]interface{})
+		assert.Len(t, msgs, 1, "should have only user message, no system message in messages array")
+		firstMsg := msgs[0].(map[string]interface{})
+		assert.Equal(t, "user", firstMsg["role"])
+
+		// Return Anthropic-format response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"content": [
+				{
+					"type": "text",
+					"text": "{\"modelname\": \"gpt-4\", \"reason\": \"Best for complex reasoning\", \"matching_tags\": [\"complex-reasoning\"], \"tag_relevance\": {\"complex-reasoning\": 9}}"
+				}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Providers: []config.ProviderConfig{
+			{
+				Name:    "az-foundry",
+				Type:    config.ProviderTypeOpenAICompatible,
+				BaseURL: "https://should-not-be-used.example.com",
+				Timeout: 5 * time.Second,
+				ModelConfigs: []config.ModelConfig{
+					{
+						Name:    "claude-opus",
+						Type:    config.ProviderTypeAnthropic,
+						BaseURL: server.URL,
+						APIKey:  "test-anthropic-key",
+					},
+				},
+			},
+		},
+		ModelSelectionModel:    "claude-opus",
+		ModelSelectionProvider: "az-foundry",
+		DefaultChatModel:       "gpt-4",
+	}
+	client := NewClient(cfg)
+
+	availableModels := map[string]models.ModelInfo{
+		"gpt-4":       {Source: "openai", Tags: `{"strengths":["complex-reasoning","code"],"weaknesses":["speed"]}`, Enabled: true},
+		"gpt-4-turbo": {Source: "openai", Tags: `{"strengths":["speed","general"],"weaknesses":["complex-reasoning"]}`, Enabled: true},
+	}
+
+	model, err := client.DecideModelBasedOnCapabilities("Write a complex algorithm", availableModels)
+	assert.NoError(t, err)
+	assert.Equal(t, "gpt-4", model)
+}
+
+func TestDecideModelBasedOnCapabilitiesWithPerModelOverrides(t *testing.T) {
+	// Verify that per-model base_url and api_key overrides are applied correctly.
+	// The provider-level URL/key should NOT be used when model_configs override them.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		assert.Equal(t, "Bearer model-specific-key", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"{\"modelname\":\"gpt-4\",\"reason\":\"test\"}"}}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Providers: []config.ProviderConfig{
+			{
+				Name:    "az-foundry",
+				Type:    config.ProviderTypeOpenAICompatible,
+				BaseURL: "https://provider-level-should-not-be-used.example.com",
+				APIKey:  "provider-level-key-should-not-be-used",
+				Timeout: 5 * time.Second,
+				ModelConfigs: []config.ModelConfig{
+					{
+						Name:    "my-judge-model",
+						BaseURL: server.URL,
+						APIKey:  "model-specific-key",
+					},
+				},
+			},
+		},
+		ModelSelectionModel:    "my-judge-model",
+		ModelSelectionProvider: "az-foundry",
+		DefaultChatModel:       "gpt-4",
+	}
+	client := NewClient(cfg)
+
+	availableModels := map[string]models.ModelInfo{
+		"gpt-4": {Source: "openai", Tags: `{"strengths":["general"]}`, Enabled: true},
+	}
+
+	model, err := client.DecideModelBasedOnCapabilities("hello", availableModels)
+	assert.NoError(t, err)
+	assert.Equal(t, "gpt-4", model)
 }
 
 func TestDecideModelBasedOnCapabilitiesFallbackWhenModelNotAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary
- **resolveJudge** and **selectionProvider** now apply `ForModel()` to resolve per-model overrides (base_url, api_key, type, chat_path) — previously they returned the raw provider-level config, causing wrong URLs and missing API keys for providers like Azure AI Foundry
- **Scorer** (benchmark judge) and **DecideModelBasedOnCapabilities** (meta-router) now support both OpenAI-compatible and Anthropic API formats with correct payload structure, auth headers, and response parsing
- Added tests for Anthropic provider selection and per-model override resolution

## Test plan
- [x] `go test -short ./...` passes
- [x] Tested with `claude-opus-4-6` via Azure AI Foundry (Anthropic format) as judge — scores parsed correctly
- [x] Tested with `gpt-5.4` via OpenAI as judge — scores parsed correctly
- [x] Verified per-model base_url and api_key overrides are applied (not provider-level defaults)
