### PR TITLE
fix(az-foundry): persist model configs and route Foundry Claude models (#38, #39)

### DIFF
--- a/cmd/server/apikeys_handlers.go
+++ b/cmd/server/apikeys_handlers.go
@@ -194,6 +194,7 @@ func (s *Server) resolveAllProviderKeys() {
 	for i := range s.config.Providers {
 		config.ResolveProviderKeys(&s.config.Providers[i])
 	}
+	s.llmClient.SetProviders(s.config.Providers)
 }
 
 // envFileMtime returns the .env file modification time as an ISO string, or empty.

--- a/cmd/server/handlers_test.go
+++ b/cmd/server/handlers_test.go
@@ -343,6 +343,10 @@ func (m *MockLLMClient) GetModelsByProvider(p config.ProviderConfig) ([]string, 
 	return args.Get(0).([]string), args.Error(1)
 }
 
+func (m *MockLLMClient) SetProviders(providers []config.ProviderConfig) {
+	m.Called(providers)
+}
+
 // Implement IsLocalServerUsingMLX to satisfy the LLMInterface
 func (m *MockLLMClient) IsLocalServerUsingMLX() bool {
 	args := m.Called()

--- a/cmd/server/interfaces.go
+++ b/cmd/server/interfaces.go
@@ -91,4 +91,5 @@ type LLMInterface interface {
 	GetModelsByProvider(p config.ProviderConfig) ([]string, error)
 	IsLocalServerUsingMLX() bool
 	UpdateTaggingPrompts(systemPrompt, userPrompt, userNoSysPrompt string)
+	SetProviders(providers []config.ProviderConfig)
 }

--- a/cmd/server/providers.go
+++ b/cmd/server/providers.go
@@ -200,6 +200,7 @@ func (s *Server) handleAddProvider(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"failed to save providers"}`, http.StatusInternalServerError)
 		return
 	}
+	s.llmClient.SetProviders(s.config.Providers)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -260,6 +261,7 @@ func (s *Server) handleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"failed to save providers"}`, http.StatusInternalServerError)
 		return
 	}
+	s.llmClient.SetProviders(s.config.Providers)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(s.toProviderResponse(*p, s.countModelsForProvider(p.Name)))
@@ -291,6 +293,7 @@ func (s *Server) handleDeleteProvider(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"failed to save providers"}`, http.StatusInternalServerError)
 		return
 	}
+	s.llmClient.SetProviders(s.config.Providers)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
@@ -328,6 +331,7 @@ func (s *Server) handleToggleProvider(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"failed to save providers"}`, http.StatusInternalServerError)
 		return
 	}
+	s.llmClient.SetProviders(s.config.Providers)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]bool{"enabled": req.Enabled})
@@ -424,6 +428,7 @@ func (s *Server) handleUpdateModelConfigs(w http.ResponseWriter, r *http.Request
 		http.Error(w, `{"error":"failed to save providers"}`, http.StatusInternalServerError)
 		return
 	}
+	s.llmClient.SetProviders(s.config.Providers)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "updated"})

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -6,6 +6,14 @@ services:
       - .env
     ports:
       - "8080:8080"
+    volumes:
+      # Bind-mount config files read-write so changes made in the Console UI
+      # (providers, model configs, API keys, settings) persist to the host
+      # files and survive container rebuilds.
+      - ./providers.json:/app/providers.json
+      - ./.env:/app/.env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - pipimink-network
     command: ["./pipimink"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,10 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./providers.json:/app/providers.json:ro
+      # Read-write so provider/model changes made in the Console UI persist
+      # to the host providers.json and survive container rebuilds.
+      - ./providers.json:/app/providers.json
+      - ./.env:/app/.env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:

--- a/internal/benchmark/scorer.go
+++ b/internal/benchmark/scorer.go
@@ -250,6 +250,11 @@ func extractOpenAIContent(body []byte) (string, error) {
 // extractAnthropicContent extracts text from an Anthropic Messages API response.
 func extractAnthropicContent(body []byte) (string, error) {
 	var result struct {
+		StopReason  string `json:"stop_reason"`
+		StopDetails struct {
+			Category    string `json:"category"`
+			Explanation string `json:"explanation"`
+		} `json:"stop_details"`
 		Content []struct {
 			Text string `json:"text"`
 		} `json:"content"`
@@ -257,10 +262,30 @@ func extractAnthropicContent(body []byte) (string, error) {
 	if err := json.Unmarshal(body, &result); err != nil {
 		return "", fmt.Errorf("error decoding Anthropic response: %w", err)
 	}
+	// A refusal is a valid 200 response with empty content and stop_reason=refusal.
+	// Surface it as a distinct error so it isn't mistaken for a parsing failure.
+	if result.StopReason == "refusal" {
+		reason := result.StopDetails.Explanation
+		if reason == "" {
+			if result.StopDetails.Category != "" {
+				reason = "blocked by provider usage policy (category: " + result.StopDetails.Category + ")"
+			} else {
+				reason = "blocked by provider usage policy"
+			}
+		}
+		return "", fmt.Errorf("model refused the request: %s", reason)
+	}
 	if len(result.Content) == 0 {
 		return "", fmt.Errorf("missing or empty content in Anthropic response")
 	}
-	return result.Content[0].Text, nil
+	// Extended-thinking models emit one or more "thinking" blocks (which have no
+	// text) before the "text" block, so return the first block that carries text.
+	for _, block := range result.Content {
+		if block.Text != "" {
+			return block.Text, nil
+		}
+	}
+	return "", fmt.Errorf("missing text in Anthropic content block")
 }
 
 func min(a, b float64) float64 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -342,7 +342,11 @@ func ResolveProviderKeys(p *ProviderConfig) {
 }
 
 // SaveProviders writes the provider list to providers.json in the given directory.
-// The write is atomic: data is written to a temp file then renamed.
+// It first attempts an atomic write (temp file + rename). If the rename fails —
+// which happens when providers.json is a single-file bind mount in Docker, where
+// renaming over the mounted inode returns EBUSY — it falls back to writing the
+// file in place. In-place writes update the mounted inode directly and therefore
+// persist to the host file.
 func SaveProviders(dir string, providers []ProviderConfig) error {
 	data, err := json.MarshalIndent(providers, "", "  ")
 	if err != nil {
@@ -356,8 +360,12 @@ func SaveProviders(dir string, providers []ProviderConfig) error {
 		return fmt.Errorf("write temp file: %w", err)
 	}
 	if err := os.Rename(tmp, path); err != nil {
+		// Atomic rename is not possible (e.g. single-file bind mount). Remove the
+		// temp file and write the target in place instead.
 		_ = os.Remove(tmp)
-		return fmt.Errorf("rename temp file: %w", err)
+		if werr := os.WriteFile(path, data, 0644); werr != nil {
+			return fmt.Errorf("write providers file in place (after rename failed: %v): %w", err, werr)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -77,3 +77,37 @@ func TestLoadReadsConfiguredValues(t *testing.T) {
 	// Providers are loaded from providers.json; without the file only the default OpenAI entry is present
 	assert.NotEmpty(t, cfg.Providers)
 }
+
+func TestSaveProvidersRoundTripAndOverwrite(t *testing.T) {
+	dir := t.TempDir()
+
+	first := []ProviderConfig{
+		{Name: "openai", Type: ProviderTypeOpenAICompatible, BaseURL: "https://api.openai.com"},
+	}
+	assert.NoError(t, SaveProviders(dir, first))
+
+	got := loadProviders(dir)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "openai", got[0].Name)
+
+	// Overwriting an existing providers.json must succeed and replace the content.
+	second := []ProviderConfig{
+		{Name: "openai", Type: ProviderTypeOpenAICompatible, BaseURL: "https://api.openai.com"},
+		{
+			Name:    "az-foundry",
+			Type:    ProviderTypeOpenAICompatible,
+			BaseURL: "https://example.cognitiveservices.azure.com",
+			ModelConfigs: []ModelConfig{
+				{Name: "claude-haiku-4-5", Type: ProviderTypeAnthropic, BaseURL: "https://example.services.ai.azure.com/anthropic"},
+			},
+		},
+	}
+	assert.NoError(t, SaveProviders(dir, second))
+
+	got = loadProviders(dir)
+	assert.Len(t, got, 2)
+	assert.Equal(t, "az-foundry", got[1].Name)
+	assert.Len(t, got[1].ModelConfigs, 1)
+	assert.Equal(t, "claude-haiku-4-5", got[1].ModelConfigs[0].Name)
+	assert.Equal(t, ProviderTypeAnthropic, got[1].ModelConfigs[0].Type)
+}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -6,6 +6,7 @@ package llm
 import (
 	"net/url"
 	"strings"
+	"sync"
 
 	"PiPiMink/internal/config"
 )
@@ -13,6 +14,7 @@ import (
 // Client is an LLM client that communicates with configured providers.
 type Client struct {
 	Config           *config.Config
+	providerMu       sync.RWMutex                     // guards providers and providerLimiters
 	providers        map[string]config.ProviderConfig // keyed by provider name
 	providerLimiters map[string]*RateLimiter          // keyed by provider name
 	decisionCache    *decisionCache
@@ -39,26 +41,48 @@ func (c *Client) UpdateTaggingPrompts(systemPrompt, userPrompt, userNoSysPrompt 
 
 // NewClient creates a new LLM client from the provided configuration.
 func NewClient(cfg *config.Config) *Client {
-	providers := make(map[string]config.ProviderConfig, len(cfg.Providers))
-	limiters := make(map[string]*RateLimiter, len(cfg.Providers))
+	c := &Client{
+		Config:           cfg,
+		providers:        make(map[string]config.ProviderConfig),
+		providerLimiters: make(map[string]*RateLimiter),
+		decisionCache:    newDecisionCache(cfg),
+	}
+	c.SetProviders(cfg.Providers)
+	return c
+}
 
-	for _, p := range cfg.Providers {
-		providers[p.Name] = p
+// SetProviders rebuilds the client's internal provider lookup and rate limiters
+// from the given provider list. Call this whenever the provider configuration
+// changes at runtime (e.g. via the console) so that chat, routing, and benchmark
+// calls use the current provider settings instead of a stale startup snapshot.
+// Existing rate limiters are preserved for providers that still exist to avoid
+// resetting their request timing.
+func (c *Client) SetProviders(providers []config.ProviderConfig) {
+	newProviders := make(map[string]config.ProviderConfig, len(providers))
+	newLimiters := make(map[string]*RateLimiter, len(providers))
+
+	c.providerMu.Lock()
+	defer c.providerMu.Unlock()
+
+	for _, p := range providers {
+		newProviders[p.Name] = p
 		if p.RateLimitSeconds > 0 {
-			limiters[p.Name] = NewRateLimiter(p.RateLimitSeconds)
+			if existing, ok := c.providerLimiters[p.Name]; ok {
+				newLimiters[p.Name] = existing
+			} else {
+				newLimiters[p.Name] = NewRateLimiter(p.RateLimitSeconds)
+			}
 		}
 	}
 
-	return &Client{
-		Config:           cfg,
-		providers:        providers,
-		providerLimiters: limiters,
-		decisionCache:    newDecisionCache(cfg),
-	}
+	c.providers = newProviders
+	c.providerLimiters = newLimiters
 }
 
 // findProvider returns the ProviderConfig for the given provider name.
 func (c *Client) findProvider(name string) (config.ProviderConfig, bool) {
+	c.providerMu.RLock()
+	defer c.providerMu.RUnlock()
 	p, ok := c.providers[name]
 	return p, ok
 }
@@ -66,6 +90,8 @@ func (c *Client) findProvider(name string) (config.ProviderConfig, bool) {
 // selectionProvider returns the ProviderConfig used for meta-routing decisions.
 // It falls back to the first openai-compatible provider if MODEL_SELECTION_PROVIDER is not set.
 func (c *Client) selectionProvider() (config.ProviderConfig, bool) {
+	c.providerMu.RLock()
+	defer c.providerMu.RUnlock()
 	name := c.Config.ModelSelectionProvider
 	if name != "" {
 		if p, ok := c.providers[name]; ok {
@@ -84,6 +110,8 @@ func (c *Client) selectionProvider() (config.ProviderConfig, bool) {
 // localProviderBaseURL returns the base URL of the first locally-running provider
 // (i.e. a provider whose host is localhost or 127.0.0.1). Used by MLX detection.
 func (c *Client) localProviderBaseURL() string {
+	c.providerMu.RLock()
+	defer c.providerMu.RUnlock()
 	for _, p := range c.providers {
 		u, err := url.Parse(p.BaseURL)
 		if err != nil {
@@ -99,5 +127,7 @@ func (c *Client) localProviderBaseURL() string {
 
 // rateLimiterFor returns the rate limiter for the given provider, or nil if none is configured.
 func (c *Client) rateLimiterFor(providerName string) *RateLimiter {
+	c.providerMu.RLock()
+	defer c.providerMu.RUnlock()
 	return c.providerLimiters[providerName]
 }

--- a/internal/llm/model_tags.go
+++ b/internal/llm/model_tags.go
@@ -479,19 +479,43 @@ func extractAnthropicContent(body []byte) (string, error) {
 		return "", fmt.Errorf("error decoding Anthropic response: %w", err)
 	}
 
+	// A refusal is a valid 200 response with empty content and stop_reason=refusal.
+	// Surface it as a distinct error so it isn't mistaken for a parsing failure.
+	if stop, _ := result["stop_reason"].(string); stop == "refusal" {
+		return "", fmt.Errorf("model refused the request: %s", anthropicRefusalReason(result))
+	}
+
 	contentArr, ok := result["content"].([]interface{})
 	if !ok || len(contentArr) == 0 {
 		return "", fmt.Errorf("missing or empty content in Anthropic response")
 	}
-	block, ok := contentArr[0].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("invalid content block format")
+	// Extended-thinking models emit one or more "thinking" blocks before the
+	// "text" block, so scan for the first block that carries text rather than
+	// assuming it is at index 0.
+	for _, raw := range contentArr {
+		block, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if text, ok := block["text"].(string); ok && text != "" {
+			return text, nil
+		}
 	}
-	text, ok := block["text"].(string)
-	if !ok {
-		return "", fmt.Errorf("missing text in Anthropic content block")
+	return "", fmt.Errorf("missing text in Anthropic content block")
+}
+
+// anthropicRefusalReason extracts a human-readable explanation from a refusal
+// response's stop_details, falling back to a generic message.
+func anthropicRefusalReason(result map[string]interface{}) string {
+	if sd, ok := result["stop_details"].(map[string]interface{}); ok {
+		if e, ok := sd["explanation"].(string); ok && e != "" {
+			return e
+		}
+		if cat, ok := sd["category"].(string); ok && cat != "" {
+			return "blocked by provider usage policy (category: " + cat + ")"
+		}
 	}
-	return text, nil
+	return "blocked by provider usage policy"
 }
 
 // isReasoningModelNoSysMsg returns true for o-series models that do not support

--- a/internal/llm/model_tags_test.go
+++ b/internal/llm/model_tags_test.go
@@ -103,6 +103,42 @@ func TestGetModelTags(t *testing.T) {
 	})
 }
 
+func TestExtractAnthropicContent(t *testing.T) {
+	t.Run("Text block only", func(t *testing.T) {
+		body := []byte(`{"content":[{"type":"text","text":"{\"strengths\":[\"a\"],\"weaknesses\":[\"b\"]}"}]}`)
+		content, err := extractAnthropicContent(body)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"strengths":["a"],"weaknesses":["b"]}`, content)
+	})
+
+	t.Run("Thinking block before text block", func(t *testing.T) {
+		body := []byte(`{"content":[{"type":"thinking","thinking":"","signature":"abc"},{"type":"text","text":"{\"strengths\":[\"a\"],\"weaknesses\":[\"b\"]}"}]}`)
+		content, err := extractAnthropicContent(body)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"strengths":["a"],"weaknesses":["b"]}`, content)
+	})
+
+	t.Run("Empty content", func(t *testing.T) {
+		body := []byte(`{"content":[]}`)
+		_, err := extractAnthropicContent(body)
+		assert.Error(t, err)
+	})
+
+	t.Run("No text block", func(t *testing.T) {
+		body := []byte(`{"content":[{"type":"thinking","thinking":"reasoning"}]}`)
+		_, err := extractAnthropicContent(body)
+		assert.Error(t, err)
+	})
+
+	t.Run("Refusal response", func(t *testing.T) {
+		body := []byte(`{"content":[],"stop_reason":"refusal","stop_details":{"type":"refusal","category":"cyber","explanation":"This request triggered restrictions on violative cyber content."}}`)
+		_, err := extractAnthropicContent(body)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "model refused the request")
+		assert.Contains(t, err.Error(), "cyber content")
+	})
+}
+
 func TestDisableModelsWithEmptyTags(t *testing.T) {
 	mockDB := new(MockDatabase)
 

--- a/scripts/start-stack.sh
+++ b/scripts/start-stack.sh
@@ -43,7 +43,9 @@ fi
 
 # Start the PiPiMink service
 echo "Starting PiPiMink service..."
-$COMPOSE_CMD -f docker-compose-app.yml up -d
+# --build ensures the image is rebuilt from the current source so code changes
+# (e.g. provider handling) are always deployed, not served from a stale image.
+$COMPOSE_CMD -f docker-compose-app.yml up -d --build
 
 # Give PiPiMink time to start up
 echo "Waiting for PiPiMink service to start (5 seconds)..."

--- a/scripts/test_chat_request.sh
+++ b/scripts/test_chat_request.sh
@@ -28,55 +28,210 @@ else
   echo "No authentication configured (anonymous mode)"
 fi
 
-echo ""
-echo "=== Single-turn: technical question ==="
-curl -s -X POST \
-  -H "Content-Type: application/json" \
-  "${AUTH_HEADER[@]}" \
-  -d '{"message": "Explain quantum computing principles and their application in cryptography, with code examples in Python"}' \
-  $API_ENDPOINT | jq .
+print_response() {
+  local response_file="$1"
 
-echo ""
-echo "=== Single-turn: creative writing ==="
-curl -s -X POST \
-  -H "Content-Type: application/json" \
-  "${AUTH_HEADER[@]}" \
-  -d '{"message": "Write a short poem about artificial intelligence"}' \
-  $API_ENDPOINT | jq .
+  if jq . <"$response_file"; then
+    return 0
+  fi
 
-echo ""
-echo "=== Single-turn: mathematical problem ==="
-curl -s -X POST \
-  -H "Content-Type: application/json" \
-  "${AUTH_HEADER[@]}" \
-  -d '{"message": "Solve the differential equation dy/dx = 2xy with the initial condition y(0) = 1"}' \
-  $API_ENDPOINT | jq .
+  echo "Response was not valid JSON. Raw response follows:"
+  cat "$response_file"
+}
 
-echo ""
-echo "=== Multi-turn: conversation history (native /chat) ==="
-curl -s -X POST \
-  -H "Content-Type: application/json" \
-  "${AUTH_HEADER[@]}" \
-  -d '{
-    "messages": [
-      {"role": "user",      "content": "How do I implement a binary search tree in Go?"},
-      {"role": "assistant", "content": "A binary search tree in Go can be implemented with a Node struct containing a value and left/right pointers..."},
-      {"role": "user",      "content": "Can you now show me how to add a delete operation to that implementation?"}
-    ]
-  }' \
-  $API_ENDPOINT | jq .
+run_native_test() {
+  local title="$1"
+  local response_file
 
-echo ""
-echo "=== Multi-turn: conversation history (OpenAI-compatible /v1/chat/completions) ==="
-curl -s -X POST \
-  -H "Content-Type: application/json" \
-  "${AUTH_HEADER[@]}" \
-  -d '{
-    "model": "gpt-4-turbo",
-    "messages": [
-      {"role": "user",      "content": "What is the difference between a mutex and a semaphore?"},
-      {"role": "assistant", "content": "A mutex provides mutual exclusion for a single resource, while a semaphore controls access to a pool of resources..."},
-      {"role": "user",      "content": "Give me a concrete Go example showing both."}
-    ]
-  }' \
-  $OPENAI_ENDPOINT | jq .
+  echo ""
+  echo "=== $title ==="
+
+  response_file=$(mktemp "${TMPDIR:-/tmp}/pipimink-chat-test.XXXXXX")
+  if ! curl -sS -X POST \
+    -H "Content-Type: application/json" \
+    "${AUTH_HEADER[@]}" \
+    --data-binary @- \
+    "$API_ENDPOINT" >"$response_file"; then
+    echo "Request failed"
+    rm -f "$response_file"
+    return 1
+  fi
+
+  print_response "$response_file"
+  rm -f "$response_file"
+}
+
+run_openai_test() {
+  local title="$1"
+  local response_file
+
+  echo ""
+  echo "=== $title ==="
+
+  response_file=$(mktemp "${TMPDIR:-/tmp}/pipimink-openai-test.XXXXXX")
+  if ! curl -sS -X POST \
+    -H "Content-Type: application/json" \
+    "${AUTH_HEADER[@]}" \
+    --data-binary @- \
+    "$OPENAI_ENDPOINT" >"$response_file"; then
+    echo "Request failed"
+    rm -f "$response_file"
+    return 1
+  fi
+
+  print_response "$response_file"
+  rm -f "$response_file"
+}
+
+run_native_test "Single-turn: technical question" <<'JSON'
+{"message": "Explain quantum computing principles and their application in cryptography, with code examples in Python"}
+JSON
+
+run_native_test "Single-turn: creative writing" <<'JSON'
+{"message": "Write a short poem about artificial intelligence"}
+JSON
+
+run_native_test "Single-turn: mathematical problem" <<'JSON'
+{"message": "Solve the differential equation dy/dx = 2xy with the initial condition y(0) = 1"}
+JSON
+
+run_native_test "Reasoning: easy deterministic" <<'JSON'
+{"message": "A train travels 120 km in 1.5 hours. What is its average speed in km/h? Respond with only the number."}
+JSON
+
+run_native_test "Reasoning: medium day-of-week" <<'JSON'
+{"message": "Today is Wednesday. A meeting is scheduled 10 days from now. What day of the week is the meeting? Respond with only the day name."}
+JSON
+
+run_native_test "Instruction-following: exact output" <<'JSON'
+{"message": "Respond with only the single word COMPLETE. No punctuation, no explanation, no other text - just the word COMPLETE."}
+JSON
+
+run_native_test "Instruction-following: strict JSON" <<'JSON'
+{"message": "Return only a valid JSON object with exactly two keys: \"language\" set to \"Go\" and \"year\" set to 2009. No markdown fences, no explanation."}
+JSON
+
+run_native_test "Instruction-following: exact 8-word sentence" <<'JSON'
+{"message": "Write a sentence about cats that contains exactly 8 words. Output only the sentence, no explanation."}
+JSON
+
+run_native_test "Creative writing: lighthouse story" <<'JSON'
+{"message": "Write a short story (150-200 words) about a lighthouse keeper who discovers an unexpected message in a bottle."}
+JSON
+
+run_native_test "Summarization: exactly 2 sentences" <<'JSON'
+{"message": "Summarize the following passage in exactly 2 sentences: The Industrial Revolution began in Britain in the late 18th century and spread through Europe and North America in the 19th century. Steam power, mechanized production, and factory systems drove urbanization and new social classes. These shifts changed family structures, work conditions, and daily life, and accelerated innovation toward the modern global economy."}
+JSON
+
+run_native_test "Factual QA: history" <<'JSON'
+{"message": "In what year did World War II end?"}
+JSON
+
+run_native_test "Factual QA: science" <<'JSON'
+{"message": "What is the chemical symbol for gold?"}
+JSON
+
+run_native_test "Go: easy word frequency" <<'JSON'
+{"message": "Write a Go function func WordFrequency(text string) map[string]int that returns a map of each word to its occurrence count. Words should be lowercased and split on whitespace. Punctuation attached to words should be stripped. Provide only the function."}
+JSON
+
+run_native_test "Go: medium concurrent fan-out" <<'JSON'
+{"message": "Write a Go function func FanOut(tasks []func() (string, error), maxWorkers int) ([]string, error) that executes the given tasks concurrently using at most maxWorkers goroutines. Return results in the same order as the input tasks slice. If any task returns an error, return that error. Provide only the function."}
+JSON
+
+run_native_test "Go: hard generic B-tree" <<'JSON'
+{"message": "Write a Go implementation of a generic B-tree with minimum degree t=2. Define type BTree[K cmp.Ordered, V any] struct with methods Insert, Search, and InOrder. The tree must correctly split nodes on overflow. Use Go 1.21+ generics with the cmp package. Provide the complete implementation."}
+JSON
+
+run_native_test "C#: easy reverse words" <<'JSON'
+{"message": "Write a C# method public static string ReverseWords(string sentence) that reverses the order of words in a sentence while normalizing whitespace. Multiple spaces become a single space and leading/trailing spaces are removed. Provide only the method."}
+JSON
+
+run_native_test "C#: medium generic LRU cache" <<'JSON'
+{"message": "Write a C# class LruCache<TKey, TValue> with a fixed capacity. It must support a constructor LruCache(int capacity), TValue Get(TKey key) that marks the item as recently used and throws KeyNotFoundException if missing, and void Put(TKey key, TValue value). All operations must be O(1). Provide only the class definition."}
+JSON
+
+run_native_test "C#: hard expression evaluator" <<'JSON'
+{"message": "Write a C# class ExpressionEvaluator with a method public static double Evaluate(string expression) that parses and evaluates mathematical expressions with +, -, *, /, parentheses, unary minus, and correct operator precedence. Throw FormatException for malformed input and DivideByZeroException for division by zero. Provide only the class."}
+JSON
+
+run_native_test "Python: easy flatten nested list" <<'JSON'
+{"message": "Write a Python function def flatten(nested: list) -> list that recursively flattens an arbitrarily nested list of integers. Do not use external libraries. Provide only the function."}
+JSON
+
+run_native_test "Python: medium retry decorator" <<'JSON'
+{"message": "Write a Python decorator retry(max_attempts: int = 3, delay: float = 1.0, backoff: float = 2.0, exceptions: tuple = (Exception,)) that retries a function on failure with exponential backoff. It must preserve the original function name and docstring and work with *args/**kwargs. Provide only the decorator."}
+JSON
+
+run_native_test "Python: hard metaclass mini ORM" <<'JSON'
+{"message": "Write a Python mini-ORM using metaclasses. Define field descriptors StringField, IntField, BoolField and a Model base class with a ModelMeta metaclass. Models should auto-detect fields, validate assignment, provide to_dict(), provide from_dict(cls, data), and generate __table_name__ from the class name. Provide the complete implementation."}
+JSON
+
+run_native_test "React: easy component with props" <<'JSON'
+{"message": "Write a React component UserBadge in TypeScript that accepts props { name: string; role: string; online: boolean } and renders a compact badge. Use a functional component, no class components, and provide only the component code."}
+JSON
+
+run_native_test "React: medium todo list with state and filters" <<'JSON'
+{"message": "Write a React TodoList component in TypeScript that supports adding todos, toggling completion, and filtering by all, active, and completed. Use hooks, keep state local, and provide only the component code."}
+JSON
+
+run_native_test "React: hard data-fetching dashboard" <<'JSON'
+{"message": "Write a React dashboard component in TypeScript that fetches a list of projects from /api/projects, shows loading and error states, supports retry, groups projects by status, and uses modern React patterns. Provide only the component code."}
+JSON
+
+run_native_test "TypeScript: easy typed emitter" <<'JSON'
+{"message": "Write a TypeScript class TypedEmitter<Events extends Record<string, unknown[]>> with on, off, and emit methods for type-safe events. Include a usage example with message: [string, number] and close: []. Provide the class and example."}
+JSON
+
+run_native_test "TypeScript: medium schema validator" <<'JSON'
+{"message": "Write a TypeScript runtime schema validator inspired by Zod. Define S.string(), S.number(), S.boolean(), S.object({...}), S.array(schema), and S.optional(schema). Each schema must expose parse(input) and safeParse(input). The output type must be inferred automatically. Provide the implementation."}
+JSON
+
+run_native_test "TypeScript: hard SQL query builder" <<'JSON'
+{"message": "Write a TypeScript type-safe SQL query builder that prevents invalid queries at compile time. Support select, where, join, orderBy, and build. The builder must enforce that select() is called before where() and that value types match column types. Provide the complete implementation."}
+JSON
+
+run_native_test "Java: easy stack from queues" <<'JSON'
+{"message": "Write a Java generic class QueueStack<T> that implements a stack using only two java.util.LinkedList instances as queues. Implement push, pop, peek, isEmpty, and size. push should be O(1) and pop should be O(n). Provide only the class."}
+JSON
+
+run_native_test "Java: medium stream pipeline" <<'JSON'
+{"message": "Write a Java class TransactionAnalyzer with a record Transaction(String customer, String category, double amount, LocalDate date) and static methods totalByCustomer, largestInCategory, and topNByCategory using Java Streams. Use Java 17+ features. Provide only the class."}
+JSON
+
+run_native_test "Java: hard lock-free queue" <<'JSON'
+{"message": "Write a Java generic lock-free concurrent queue class LockFreeQueue<T> using AtomicReference and compare-and-swap. Implement enqueue, dequeue, and isEmpty using the Michael-Scott algorithm with a sentinel node. Provide only the class."}
+JSON
+
+run_native_test "Security: Go path traversal review" <<'JSON'
+{"message": "Review this Go HTTP handler for security vulnerabilities. Identify all issues, explain exploitation paths, and provide a secure version: func downloadHandler(w http.ResponseWriter, r *http.Request) { filename := r.URL.Query().Get(\"file\"); filepath := \"./uploads/\" + filename; data, err := os.ReadFile(filepath); if err != nil { http.Error(w, fmt.Sprintf(\"Error reading %s: %v\", filepath, err), 500); return }; w.Header().Set(\"Content-Type\", \"application/octet-stream\"); w.Header().Set(\"Content-Disposition\", fmt.Sprintf(\"attachment; filename=%s\", filename)); w.Write(data) }"}
+JSON
+
+run_native_test "Security: Python Flask SQL injection and XSS review" <<'JSON'
+{"message": "Review the following Python Flask endpoint for security vulnerabilities. Identify all vulnerabilities, explain why each is dangerous, and provide a corrected version: @app.route('/search') def search(): query = request.args.get('q'); sql = f\"SELECT * FROM products WHERE name LIKE '%{query}%'\"; results = db.engine.execute(sql); return render_template_string(f'<h1>Results for {query}</h1>' + ''.join(f'<p>{row.name}: ${row.price}</p>' for row in results))"}
+JSON
+
+run_native_test "Security: Node.js JWT authentication review" <<'JSON'
+{"message": "Review this Node.js Express authentication middleware for security vulnerabilities. Identify all issues, explain the attack vectors, and provide a secure implementation: const jwt = require('jsonwebtoken'); function authMiddleware(req, res, next) { const token = req.headers.authorization; try { const decoded = jwt.verify(token, 'mysecretkey123'); req.user = decoded; next(); } catch(e) { res.status(401).json({ error: e.message }); } } app.post('/login', (req, res) => { const { username, password } = req.body; const user = users.find(u => u.username === username && u.password === password); if (user) { const token = jwt.sign({ id: user.id, role: user.role, password: user.password }, 'mysecretkey123'); res.json({ token }); } else { res.status(401).json({ error: 'Invalid credentials' }); } });"}
+JSON
+
+run_native_test "Multi-turn: conversation history (native /chat)" <<'JSON'
+{
+  "messages": [
+    {"role": "user", "content": "How do I implement a binary search tree in Go?"},
+    {"role": "assistant", "content": "A binary search tree in Go can be implemented with a Node struct containing a value and left/right pointers..."},
+    {"role": "user", "content": "Can you now show me how to add a delete operation to that implementation?"}
+  ]
+}
+JSON
+
+run_openai_test "Multi-turn: conversation history (OpenAI-compatible /v1/chat/completions)" <<'JSON'
+{
+  "model": "gpt-4-turbo",
+  "messages": [
+    {"role": "user", "content": "What is the difference between a mutex and a semaphore?"},
+    {"role": "assistant", "content": "A mutex provides mutual exclusion for a single resource, while a semaphore controls access to a pool of resources..."},
+    {"role": "user", "content": "Give me a concrete Go example showing both."}
+  ]
+}
+JSON


### PR DESCRIPTION
## Summary

Fixes two Azure AI Foundry bugs reported in the tracker.

### #38 — Add Config within AZFoundry doesn't save properly
- `SaveProviders` used an atomic temp-file + `os.Rename`, which fails with
  `EBUSY` ("device or resource busy") when `providers.json` is a **single-file
  Docker bind mount**. The write silently errored, so UI changes never reached
  the host file and were lost on restart. It now falls back to an **in-place
  write** when rename fails.
- `providers.json` and `.env` are now bind-mounted **read-write** in
  `docker-compose-app.yml` and `docker-compose.yml`, so Console UI changes
  persist to the host and survive container rebuilds.
- `llm.Client` held a **stale provider snapshot** from startup. Added
  `SetProviders()` (mutex-guarded) and wired it into every provider mutation
  handler (add/update/delete/toggle/model-configs, API-key resolution) so chat,
  routing, and benchmark always use the current config — not a stale map. This
  is why tagging (live config) worked but benchmarking (stale client map) 404'd.

### #39 — Microsoft Foundry Claude Fable 5 doesn't work
- Anthropic response parsing only read `content[0]`. Extended-thinking models
  (Fable 5, Haiku 4.5, …) emit a `thinking` block **before** the `text` block,
  so parsing failed with "missing/empty content". It now scans all content
  blocks for the first one carrying text.
- Provider-type resolution for Azure Foundry Claude models now resolves to
  `anthropic` consistently (see `SetProviders` above), so calls hit
  `/v1/messages` instead of the OpenAI-compatible endpoint (which 404'd).
- Policy **refusals** (`stop_reason=refusal`) are surfaced as a distinct,
  clear error instead of a misleading "empty content" message.

### Misc
- `start-stack.sh` now rebuilds the app image (`up -d --build`) so code changes
  are actually deployed.
- Expanded `scripts/test_chat_request.sh` with benchmark-aligned prompts.

## Tests
- `go build ./...`, `go vet`, and targeted `go test` (incl. `-race`) pass.
- New tests: `TestExtractAnthropicContent` (thinking-block + refusal cases),
  `TestSaveProvidersRoundTripAndOverwrite`.

Fixes #38
Fixes #39
