### PR TITLE
chore(docs): rename CLAUDE.md to AGENTS.md and update changelog

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,7 +10,7 @@
     '''SECURITY\.md''',
     '''CONTRIBUTING\.md''',
     '''CHANGELOG\.md''',
-    '''CLAUDE\.md''',
+    '''AGENTS\.md''',
     '''\.github/copilot-instructions\.md''',
   ]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# PiPiMink — Project Context for Claude
+# PiPiMink — Project Context for AI Coding Agents
 
 ## What this project is
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Azure AI Foundry: provider and per-model config changes made in the Console UI now persist to `providers.json`. `SaveProviders` used an atomic temp-file + rename, which fails with `EBUSY` on single-file Docker bind mounts; it now falls back to an in-place write. `providers.json` and `.env` are bind-mounted read-write in the compose files so UI changes survive container rebuilds.
+- Provider config changes now propagate to the running LLM client immediately. The client held a provider snapshot from startup; a mutex-guarded `SetProviders()` is now invoked from every provider mutation handler, so chat, routing, and benchmark use the current config instead of a stale map (previously tagging worked but chat/benchmark hit the wrong endpoint).
+- Anthropic response parsing now scans all content blocks: extended-thinking models (e.g. Claude on Azure Foundry) emit a `thinking` block before the `text` block, which previously caused "missing/empty content" failures during tagging, chat, and benchmarking.
+- Anthropic policy refusals (`stop_reason=refusal`) are now surfaced as a distinct, clear error instead of a misleading "empty content" message.
+- `scripts/start-stack.sh` now rebuilds the app image (`up -d --build`) so code changes are actually deployed to the running container.
 - Analytics latency time series query using incorrect `date_trunc` unit strings (`"1 hour"` → `"hour"`)
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ This project was built with the help of AI coding tools (Claude Code, GitHub Cop
 
 - **Understand what you submit.** Review every line of AI-generated code before committing. You are responsible for the correctness, security, and maintainability of your contribution — not the AI.
 - **Test thoroughly.** AI-generated code can look plausible while being subtly wrong. Run the full test suite (`go test ./...`) and verify edge cases manually.
-- **Respect the architecture.** AI tools sometimes ignore existing patterns or invent unnecessary abstractions. Follow the conventions described in this guide and in `CLAUDE.md`.
+- **Respect the architecture.** AI tools sometimes ignore existing patterns or invent unnecessary abstractions. Follow the conventions described in this guide and in `AGENTS.md`.
 - **Do not blindly paste.** If you do not understand why a piece of generated code works, do not include it. Ask questions in the PR instead.
 - **Disclose when helpful.** You are not required to label every AI-assisted line, but if a PR contains substantial AI-generated logic, a brief note in the PR description helps reviewers calibrate their review.
 


### PR DESCRIPTION
## Summary

Documentation/housekeeping chore.

- **Rename `CLAUDE.md` → `AGENTS.md`** (history preserved via `git mv`) and
  generalize the title to *"Project Context for AI Coding Agents"* so the
  project-context doc is tool-agnostic (works for any agent, not just Claude).
- **Update references** to the renamed file so nothing dangles:
  - `.gitleaks.toml` allowlist entry
  - `CONTRIBUTING.md` architecture note
- **CHANGELOG** — record the recent Azure AI Foundry fixes under `[Unreleased] → Fixed`
  (they were previously undocumented):
  - Provider/model-config persistence: `SaveProviders` falls back to an in-place
    write when atomic rename fails on single-file Docker bind mounts; compose
    files bind-mount `providers.json`/`.env` read-write.
  - Live provider propagation via a mutex-guarded `SetProviders()` from all
    provider mutation handlers.
  - Anthropic response parsing scans all content blocks (extended-thinking
    `thinking` block before `text`) and surfaces policy refusals distinctly.
  - `start-stack.sh` rebuilds the app image (`up -d --build`).

No code or API changes. README/SETUP were checked — they don't reference the
renamed file, and remaining "Claude" mentions refer to the Anthropic models.
