### PR TITLE
Support Azure AI Foundry OpenAI models via the Responses API (Fixes #47)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ AZURE_FOUNDRY_LLAMA_API_KEY=your-key-here
 AZURE_FOUNDRY_CLAUDE_OPUS_API_KEY=your-key-here
 # Project-scoped OpenAI models:
 AZURE_FOUNDRY_GPT4O_API_KEY=your-key-here
+# Responses-API OpenAI models (gpt-5.x and newer; type "openai-responses", chat_path "/openai/v1/responses"):
+AZURE_FOUNDRY_GPT5_API_KEY=your-key-here
 # Legacy Azure OpenAI deployment (single model per deployment, no model_configs needed):
 AZURE_GPT4O_API_KEY=your-azure-gpt4o-key-here
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -129,12 +129,14 @@ Providers are configured in **`providers.json`** (copy from `providers.example.j
 | Field | Meaning |
 | --- | --- |
 | `name` | Unique identifier; stored as `source` in the model registry |
-| `type` | `openai-compatible` or `anthropic` |
+| `type` | `openai-compatible`, `openai-responses`, or `anthropic` |
 | `api_key_env` | Env var name holding the API key |
 | `models` | Empty = auto-discover via `/v1/models`; non-empty = static list (Anthropic, Azure) |
 | `rate_limit_seconds` | Min seconds between requests (0 = unlimited) |
 
 Azure AI Foundry: one `ProviderConfig` entry per deployment, with `"models": ["model-name"]`.
+
+Azure AI Foundry OpenAI models on the Responses API (`/openai/v1/responses`) use `type: openai-responses` (requests send `input`, responses parse `output`). PiPiMink also auto-detects the Responses API when a `chat_path` contains `/responses`. Request building/parsing lives in `internal/llm/responses.go`; `ProviderConfig.UsesResponsesAPI()` and `ResponsesURL()` in `internal/config/config.go` drive the dispatch.
 
 ## Important configuration defaults
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,12 +121,14 @@ Providers are configured in **`providers.json`** (copy from `providers.example.j
 | Field | Meaning |
 | --- | --- |
 | `name` | Unique identifier; stored as `source` in the model registry |
-| `type` | `openai-compatible` or `anthropic` |
+| `type` | `openai-compatible`, `openai-responses`, or `anthropic` |
 | `api_key_env` | Env var name holding the API key |
 | `models` | Empty = auto-discover via `/v1/models`; non-empty = static list (Anthropic, Azure) |
 | `rate_limit_seconds` | Min seconds between requests (0 = unlimited) |
 
 Azure AI Foundry: one `ProviderConfig` entry per deployment, with `"models": ["model-name"]`.
+
+Azure AI Foundry OpenAI models on the Responses API (`/openai/v1/responses`) use `type: openai-responses` (requests send `input`, responses parse `output`). PiPiMink also auto-detects the Responses API when a `chat_path` contains `/responses`. Request building/parsing lives in `internal/llm/responses.go`; `ProviderConfig.UsesResponsesAPI()` and `ResponsesURL()` in `internal/config/config.go` drive the dispatch.
 
 ## Important configuration defaults
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Azure AI Foundry OpenAI models via the **Responses API** (`/openai/v1/responses`): new provider type `openai-responses` (plus auto-detection when a `chat_path` targets `/responses`). Requests use the `input` field and responses are parsed from the `output` array, so Foundry OpenAI deployments (e.g. `gpt-5.x`) can be tagged, routed, chatted, and benchmarked. `temperature` and `max_output_tokens` are omitted by default so reasoning models are not rejected. The console UI exposes the new type in the provider and per-model selectors. Fixes #47.
 - 3-tier authentication model: Public (unauthenticated), User (session or Bearer token), Admin (X-API-Key or admin session)
   - Centralized auth middleware enforces tiers on all routes — new handlers must not perform inline auth checks
   - Bearer token support: per-user API tokens for programmatic access (`POST /auth/tokens`, `GET /auth/tokens`, `DELETE /auth/tokens/{id}`)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Routing decisions are cached in memory using a hash of the normalized prompt and
 | Type | Examples |
 | --- | --- |
 | `openai-compatible` | OpenAI, Gemini, OpenRouter, LM Studio, any local server (Ollama, llama.cpp, MLX) |
+| `openai-responses` | OpenAI Responses API endpoints (e.g. Azure AI Foundry `/openai/v1/responses`) |
 | `anthropic` | Anthropic Claude (uses the native Messages API) |
 
 Azure AI Foundry is supported via per-model `model_configs` entries. See [SETUP.md](SETUP.md#microsoft-azure-ai-foundry) for details.

--- a/SETUP.md
+++ b/SETUP.md
@@ -95,6 +95,7 @@ flowchart TD
     R -->|Serverless-API models\nMistral · Llama · Phi · Cohere · DeepSeek| P1["/models/chat/completions\n?api-version=2024-05-01-preview"]
     R -->|Anthropic models\nClaude family| P2["/anthropic/v1/messages"]
     R -->|Project-scoped OpenAI models\nGPT-4o · o-series| P3["/api/projects/MY-PROJECT\n/openai/v1/chat/completions"]
+    R -->|Responses-API OpenAI models\ngpt-5.x · newer o-series| P4["/openai/v1/responses"]
 ```
 
 | Pattern | Models | `type` | Path in `chat_path` |
@@ -102,6 +103,7 @@ flowchart TD
 | **Serverless-API** | Mistral, Llama, Phi, Cohere, DeepSeek, … | `openai-compatible` | `/models/chat/completions?api-version=2024-05-01-preview` |
 | **Anthropic** | Claude family | `anthropic` | *(not needed — set `base_url` to `…/anthropic`)* |
 | **Project-scoped** | GPT-4o, o-series | `openai-compatible` | `/api/projects/YOUR-PROJECT/openai/v1/chat/completions` |
+| **Responses-API** | gpt-5.x, newer OpenAI models | `openai-responses` | `/openai/v1/responses` |
 
 #### Configuration
 
@@ -140,6 +142,12 @@ flowchart TD
       "name": "gpt-4o",
       "chat_path": "/api/projects/MY-PROJECT/openai/v1/chat/completions",
       "api_key_env": "AZURE_FOUNDRY_GPT4O_API_KEY"
+    },
+    {
+      "name": "gpt-5",
+      "type": "openai-responses",
+      "chat_path": "/openai/v1/responses",
+      "api_key_env": "AZURE_FOUNDRY_GPT5_API_KEY"
     }
   ]
 }
@@ -155,6 +163,7 @@ AZURE_FOUNDRY_PHI4_API_KEY=xK9mNpLw...
 AZURE_FOUNDRY_LLAMA_API_KEY=tR3vQsYz...
 AZURE_FOUNDRY_CLAUDE_OPUS_API_KEY=aB7cDeFg...
 AZURE_FOUNDRY_GPT4O_API_KEY=hI2jKlMn...
+AZURE_FOUNDRY_GPT5_API_KEY=oP4qRsTu...
 ```
 
 **Step 3 — Discover and tag as usual:**
@@ -168,6 +177,7 @@ In the [Azure AI Foundry portal](https://ai.azure.com):
 - **Serverless-API models** (Mistral, Llama, Phi, etc.): go to **Models + endpoints**, select the deployment — the endpoint URL and key are shown on the detail page.
 - **Anthropic models**: same location; the URL ends with `/anthropic/v1/messages`. Use everything before `/v1/messages` as `base_url` in the model config.
 - **Project-scoped models** (GPT, o-series): go to **My assets → Models + endpoints** inside your project — copy the endpoint. The path starts with `/api/projects/YOUR-PROJECT/openai/v1/`.
+- **Responses-API models** (gpt-5.x and newer OpenAI models): these are served from the resource-level `/openai/v1/responses` endpoint. Set `type` to `openai-responses` and `chat_path` to `/openai/v1/responses`. PiPiMink sends the prompt in the `input` field and reads the answer from the `output` array. If you only override `chat_path` to a `/responses` path without setting the type, PiPiMink still auto-detects and uses the Responses API.
 
 ## 3. Start the stack
 

--- a/internal/benchmark/scorer.go
+++ b/internal/benchmark/scorer.go
@@ -102,9 +102,11 @@ func (s *Scorer) scoreLLMJudge(ctx context.Context, task Task, response string) 
 	var url string
 	var err error
 
-	switch s.judgeProvider.Type {
-	case config.ProviderTypeAnthropic:
+	switch {
+	case s.judgeProvider.Type == config.ProviderTypeAnthropic:
 		body, url, err = s.buildAnthropicRequest(systemMsg, userMsg)
+	case s.judgeProvider.UsesResponsesAPI():
+		body, url, err = s.buildResponsesRequest(systemMsg, userMsg)
 	default:
 		body, url, err = s.buildOpenAIRequest(systemMsg, userMsg)
 	}
@@ -207,6 +209,24 @@ func (s *Scorer) buildOpenAIRequest(systemMsg, userMsg string) ([]byte, string, 
 	return body, s.judgeProvider.ChatCompletionsURL(), nil
 }
 
+// buildResponsesRequest builds the JSON payload and URL for an OpenAI Responses API judge
+// request. The prompt is sent in "input"; temperature and max_output_tokens are omitted so
+// reasoning models are not rejected.
+func (s *Scorer) buildResponsesRequest(systemMsg, userMsg string) ([]byte, string, error) {
+	payload := map[string]interface{}{
+		"model": s.judgeModel,
+		"input": []map[string]interface{}{
+			{"role": "system", "content": systemMsg},
+			{"role": "user", "content": userMsg},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, s.judgeProvider.ResponsesURL(), nil
+}
+
 // buildAnthropicRequest builds the JSON payload and URL for an Anthropic Messages API judge request.
 func (s *Scorer) buildAnthropicRequest(systemMsg, userMsg string) ([]byte, string, error) {
 	payload := map[string]interface{}{
@@ -225,11 +245,13 @@ func (s *Scorer) buildAnthropicRequest(systemMsg, userMsg string) ([]byte, strin
 }
 
 // extractJudgeContent extracts the text content from a judge API response,
-// handling both OpenAI and Anthropic response formats.
+// handling OpenAI Chat Completions, OpenAI Responses, and Anthropic response formats.
 func (s *Scorer) extractJudgeContent(body []byte) (string, error) {
-	switch s.judgeProvider.Type {
-	case config.ProviderTypeAnthropic:
+	switch {
+	case s.judgeProvider.Type == config.ProviderTypeAnthropic:
 		return extractAnthropicContent(body)
+	case s.judgeProvider.UsesResponsesAPI():
+		return extractResponsesContent(body)
 	default:
 		return extractOpenAIContent(body)
 	}
@@ -251,6 +273,50 @@ func extractOpenAIContent(body []byte) (string, error) {
 		return "", fmt.Errorf("missing or empty choices in OpenAI response")
 	}
 	return apiResp.Choices[0].Message.Content, nil
+}
+
+// extractResponsesContent extracts text from an OpenAI Responses API response.
+// It concatenates every "output_text" part in "message" items, honours a top-level
+// "output_text" convenience field, and surfaces API errors.
+func extractResponsesContent(body []byte) (string, error) {
+	var apiResp struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		OutputText string `json:"output_text"`
+		Output     []struct {
+			Type    string `json:"type"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return "", fmt.Errorf("error decoding Responses API response: %w", err)
+	}
+	if apiResp.Error != nil && apiResp.Error.Message != "" {
+		return "", fmt.Errorf("Responses API error: %s", apiResp.Error.Message)
+	}
+	var sb strings.Builder
+	for _, item := range apiResp.Output {
+		if item.Type != "message" {
+			continue
+		}
+		for _, part := range item.Content {
+			if part.Type == "output_text" {
+				sb.WriteString(part.Text)
+			}
+		}
+	}
+	text := sb.String()
+	if text == "" {
+		text = apiResp.OutputText
+	}
+	if text == "" {
+		return "", fmt.Errorf("missing text in Responses API output")
+	}
+	return text, nil
 }
 
 // extractAnthropicContent extracts text from an Anthropic Messages API response.

--- a/internal/benchmark/scorer.go
+++ b/internal/benchmark/scorer.go
@@ -296,7 +296,7 @@ func extractResponsesContent(body []byte) (string, error) {
 		return "", fmt.Errorf("error decoding Responses API response: %w", err)
 	}
 	if apiResp.Error != nil && apiResp.Error.Message != "" {
-		return "", fmt.Errorf("Responses API error: %s", apiResp.Error.Message)
+		return "", fmt.Errorf("responses API error: %s", apiResp.Error.Message)
 	}
 	var sb strings.Builder
 	for _, item := range apiResp.Output {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,10 +90,11 @@ func (p ProviderConfig) ForModel(name string) ProviderConfig {
 // ChatCompletionsURL returns the full URL for the chat completions endpoint.
 // If ChatPath is set it overrides the default /v1/chat/completions path.
 func (p ProviderConfig) ChatCompletionsURL() string {
+	base := strings.TrimRight(p.BaseURL, "/")
 	if p.ChatPath != "" {
-		return p.BaseURL + p.ChatPath
+		return base + p.ChatPath
 	}
-	return p.BaseURL + "/v1/chat/completions"
+	return base + "/v1/chat/completions"
 }
 
 // UsesResponsesAPI reports whether requests to this provider/model must use the
@@ -112,12 +113,19 @@ func (p ProviderConfig) UsesResponsesAPI() bool {
 }
 
 // ResponsesURL returns the full URL for the OpenAI Responses API endpoint.
-// If ChatPath is set it overrides the default /v1/responses path.
+// If ChatPath is set it overrides the default path. Otherwise the default is
+// chosen by host: Azure AI Foundry serves the Responses API under
+// /openai/v1/responses, whereas OpenAI itself uses /v1/responses. This lets the
+// openai-responses type work out of the box without an explicit chat_path.
 func (p ProviderConfig) ResponsesURL() string {
+	base := strings.TrimRight(p.BaseURL, "/")
 	if p.ChatPath != "" {
-		return p.BaseURL + p.ChatPath
+		return base + p.ChatPath
 	}
-	return p.BaseURL + "/v1/responses"
+	if strings.Contains(strings.ToLower(base), "azure.com") {
+		return base + "/openai/v1/responses"
+	}
+	return base + "/v1/responses"
 }
 
 // OAuthEnabled returns true when all required OAuth fields are configured.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,8 @@ import (
 
 // ProviderType defines the API format a provider speaks.
 const (
-	ProviderTypeOpenAICompatible = "openai-compatible" // OpenAI, Gemini, OpenRouter, local, Azure AI Foundry
+	ProviderTypeOpenAICompatible = "openai-compatible" // OpenAI, Gemini, OpenRouter, local, Azure AI Foundry (Chat Completions)
+	ProviderTypeOpenAIResponses  = "openai-responses"  // OpenAI Responses API (input/output), e.g. Azure AI Foundry /openai/v1/responses
 	ProviderTypeAnthropic        = "anthropic"         // Anthropic Claude models
 )
 
@@ -93,6 +94,30 @@ func (p ProviderConfig) ChatCompletionsURL() string {
 		return p.BaseURL + p.ChatPath
 	}
 	return p.BaseURL + "/v1/chat/completions"
+}
+
+// UsesResponsesAPI reports whether requests to this provider/model must use the
+// OpenAI Responses API format (input/output) rather than Chat Completions
+// (messages/choices).
+//
+// It is true when the provider type is explicitly "openai-responses", or when the
+// configured chat path targets a "/responses" endpoint. The path-based check makes
+// existing configs that only override chat_path work without a type change, and
+// keeps PiPiMink forward-compatible as more providers migrate to the Responses API.
+func (p ProviderConfig) UsesResponsesAPI() bool {
+	if p.Type == ProviderTypeOpenAIResponses {
+		return true
+	}
+	return strings.Contains(p.ChatPath, "/responses")
+}
+
+// ResponsesURL returns the full URL for the OpenAI Responses API endpoint.
+// If ChatPath is set it overrides the default /v1/responses path.
+func (p ProviderConfig) ResponsesURL() string {
+	if p.ChatPath != "" {
+		return p.BaseURL + p.ChatPath
+	}
+	return p.BaseURL + "/v1/responses"
 }
 
 // OAuthEnabled returns true when all required OAuth fields are configured.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -111,3 +111,48 @@ func TestSaveProvidersRoundTripAndOverwrite(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", got[1].ModelConfigs[0].Name)
 	assert.Equal(t, ProviderTypeAnthropic, got[1].ModelConfigs[0].Type)
 }
+
+func TestUsesResponsesAPI(t *testing.T) {
+	// Explicit type.
+	p := ProviderConfig{Type: ProviderTypeOpenAIResponses, BaseURL: "https://x"}
+	assert.True(t, p.UsesResponsesAPI())
+
+	// Auto-detected via chat path.
+	p = ProviderConfig{Type: ProviderTypeOpenAICompatible, ChatPath: "/openai/v1/responses"}
+	assert.True(t, p.UsesResponsesAPI())
+
+	// Plain chat completions provider must not be treated as Responses API.
+	p = ProviderConfig{Type: ProviderTypeOpenAICompatible, ChatPath: "/v1/chat/completions"}
+	assert.False(t, p.UsesResponsesAPI())
+
+	p = ProviderConfig{Type: ProviderTypeOpenAICompatible}
+	assert.False(t, p.UsesResponsesAPI())
+}
+
+func TestResponsesURL(t *testing.T) {
+	// Default path.
+	p := ProviderConfig{Type: ProviderTypeOpenAIResponses, BaseURL: "https://api.openai.com"}
+	assert.Equal(t, "https://api.openai.com/v1/responses", p.ResponsesURL())
+
+	// Explicit chat path override (Azure AI Foundry).
+	p = ProviderConfig{
+		Type:     ProviderTypeOpenAIResponses,
+		BaseURL:  "https://x.services.ai.azure.com",
+		ChatPath: "/openai/v1/responses",
+	}
+	assert.Equal(t, "https://x.services.ai.azure.com/openai/v1/responses", p.ResponsesURL())
+}
+
+func TestForModelAppliesResponsesTypeOverride(t *testing.T) {
+	p := ProviderConfig{
+		Name:    "az-foundry",
+		Type:    ProviderTypeOpenAICompatible,
+		BaseURL: "https://x.services.ai.azure.com",
+		ModelConfigs: []ModelConfig{
+			{Name: "gpt-5", Type: ProviderTypeOpenAIResponses, ChatPath: "/openai/v1/responses"},
+		},
+	}
+	resolved := p.ForModel("gpt-5")
+	assert.True(t, resolved.UsesResponsesAPI())
+	assert.Equal(t, "https://x.services.ai.azure.com/openai/v1/responses", resolved.ResponsesURL())
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -130,11 +130,19 @@ func TestUsesResponsesAPI(t *testing.T) {
 }
 
 func TestResponsesURL(t *testing.T) {
-	// Default path.
+	// Default path for OpenAI.
 	p := ProviderConfig{Type: ProviderTypeOpenAIResponses, BaseURL: "https://api.openai.com"}
 	assert.Equal(t, "https://api.openai.com/v1/responses", p.ResponsesURL())
 
-	// Explicit chat path override (Azure AI Foundry).
+	// Azure AI Foundry host defaults to /openai/v1/responses without an explicit chat_path.
+	p = ProviderConfig{Type: ProviderTypeOpenAIResponses, BaseURL: "https://x.services.ai.azure.com"}
+	assert.Equal(t, "https://x.services.ai.azure.com/openai/v1/responses", p.ResponsesURL())
+
+	// Trailing slash on the base URL must not produce a double slash.
+	p = ProviderConfig{Type: ProviderTypeOpenAIResponses, BaseURL: "https://x.services.ai.azure.com/"}
+	assert.Equal(t, "https://x.services.ai.azure.com/openai/v1/responses", p.ResponsesURL())
+
+	// Explicit chat path override wins.
 	p = ProviderConfig{
 		Type:     ProviderTypeOpenAIResponses,
 		BaseURL:  "https://x.services.ai.azure.com",

--- a/internal/llm/chat.go
+++ b/internal/llm/chat.go
@@ -163,9 +163,9 @@ func (c *Client) chatWithOpenAIResponsesModel(p config.ProviderConfig, model str
 
 	if status >= 400 {
 		if msg := extractAPIErrorMessage(body); msg != "" {
-			return "", fmt.Errorf("Responses API error (HTTP %d): %s", status, msg)
+			return "", fmt.Errorf("responses API error (HTTP %d): %s", status, msg)
 		}
-		return "", fmt.Errorf("Responses API returned HTTP %d", status)
+		return "", fmt.Errorf("responses API returned HTTP %d", status)
 	}
 
 	content, err := extractResponsesContent(body)

--- a/internal/llm/chat.go
+++ b/internal/llm/chat.go
@@ -35,9 +35,11 @@ func (c *Client) ChatWithModel(modelInfo models.ModelInfo, model string, message
 		defer rl.UpdateLastRequestTime()
 	}
 
-	switch p.Type {
-	case config.ProviderTypeAnthropic:
+	switch {
+	case p.Type == config.ProviderTypeAnthropic:
 		return c.chatWithAnthropicModel(p, model, messages)
+	case p.UsesResponsesAPI():
+		return c.chatWithOpenAIResponsesModel(p, model, messages)
 	default:
 		return c.chatWithOpenAICompatibleModel(p, model, messages)
 	}
@@ -143,7 +145,37 @@ func (c *Client) chatWithOpenAICompatibleModel(p config.ProviderConfig, model st
 	return content, nil
 }
 
-// chatWithAnthropicModel sends a chat request using the Anthropic Messages API.
+// chatWithOpenAIResponsesModel sends a chat request using the OpenAI Responses API.
+// The conversation is passed in "input" and the answer is read from the "output" array.
+// temperature and max_output_tokens are omitted so reasoning models (o-series, gpt-5.x)
+// are not rejected and are free to allocate their own output budget.
+func (c *Client) chatWithOpenAIResponsesModel(p config.ProviderConfig, model string, messages []map[string]interface{}) (string, error) {
+	url := p.ResponsesURL()
+	payload := buildResponsesPayload(model, messages, responsesRequestOptions{})
+
+	log.Printf("Sending Responses API chat request to %s for model %s", url, model)
+	body, status, err := sendResponsesRequest(url, p.APIKey, payload, p.Timeout)
+	if err != nil {
+		return "", err
+	}
+	log.Printf("Received Responses API response with status code: %d", status)
+	log.Printf("Raw Responses API response: %s", string(body))
+
+	if status >= 400 {
+		if msg := extractAPIErrorMessage(body); msg != "" {
+			return "", fmt.Errorf("Responses API error (HTTP %d): %s", status, msg)
+		}
+		return "", fmt.Errorf("Responses API returned HTTP %d", status)
+	}
+
+	content, err := extractResponsesContent(body)
+	if err != nil {
+		return "", err
+	}
+	log.Printf("Successfully extracted Responses API content (%d characters)", len(content))
+	return content, nil
+}
+
 // It converts the OpenAI-format messages array into Anthropic's format:
 // system messages are extracted to the top-level "system" field; all other
 // messages are kept in the messages array with only "user" and "assistant" roles.

--- a/internal/llm/chat_test.go
+++ b/internal/llm/chat_test.go
@@ -1,6 +1,11 @@
 package llm
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,4 +96,44 @@ func TestChatWithModel(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "This is a test response", response)
 	})
+}
+
+func TestChatWithModelResponsesAPI(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"responses answer"}]}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Providers: []config.ProviderConfig{
+			{
+				Name:    "az-foundry",
+				Type:    config.ProviderTypeOpenAICompatible,
+				BaseURL: server.URL,
+				Timeout: 5 * time.Second,
+				ModelConfigs: []config.ModelConfig{
+					{Name: "gpt-5", Type: config.ProviderTypeOpenAIResponses, ChatPath: "/openai/v1/responses", APIKey: "test-key"},
+				},
+			},
+		},
+	}
+	client := NewClient(cfg)
+
+	modelInfo := models.ModelInfo{Source: "az-foundry", Enabled: true}
+	response, err := client.ChatWithModel(modelInfo, "gpt-5", []map[string]interface{}{
+		{"role": "user", "content": "Hello"},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "responses answer", response)
+	assert.True(t, strings.HasSuffix(gotPath, "/openai/v1/responses"), "must hit the Responses endpoint, got %s", gotPath)
+	assert.Contains(t, gotBody, "input", "request must use 'input'")
+	assert.NotContains(t, gotBody, "messages", "request must not use 'messages'")
 }

--- a/internal/llm/model_selection.go
+++ b/internal/llm/model_selection.go
@@ -178,8 +178,8 @@ func (c *Client) DecideModelBasedOnCapabilities(message string, availableModels 
 	var jsonPayload []byte
 	var endpoint string
 
-	switch selProvider.Type {
-	case config.ProviderTypeAnthropic:
+	switch {
+	case selProvider.Type == config.ProviderTypeAnthropic:
 		maxTokens := c.Config.AnthropicMaxTokens
 		if maxTokens <= 0 {
 			maxTokens = 12800
@@ -194,6 +194,13 @@ func (c *Client) DecideModelBasedOnCapabilities(message string, availableModels 
 		}
 		jsonPayload, err = json.Marshal(payload)
 		endpoint = selProvider.BaseURL + "/v1/messages"
+	case selProvider.UsesResponsesAPI():
+		payload := buildResponsesPayload(selectionModel, []map[string]interface{}{
+			{"role": "system", "content": systemMessage},
+			{"role": "user", "content": message},
+		}, responsesRequestOptions{})
+		jsonPayload, err = json.Marshal(payload)
+		endpoint = selProvider.ResponsesURL()
 	default:
 		payload := map[string]interface{}{
 			"model":       selectionModel,
@@ -249,11 +256,16 @@ func (c *Client) DecideModelBasedOnCapabilities(message string, availableModels 
 
 	// Extract text content from the response based on provider type.
 	var content string
-	switch selProvider.Type {
-	case config.ProviderTypeAnthropic:
+	switch {
+	case selProvider.Type == config.ProviderTypeAnthropic:
 		content, err = extractAnthropicContent(responseBody.Bytes())
 		if err != nil {
 			return errResult(fmt.Errorf("error extracting content from Anthropic response: %w", err))
+		}
+	case selProvider.UsesResponsesAPI():
+		content, err = extractResponsesContent(responseBody.Bytes())
+		if err != nil {
+			return errResult(fmt.Errorf("error extracting content from Responses API response: %w", err))
 		}
 	default:
 		content, err = extractOpenAISelectionContent(responseBody.Bytes())

--- a/internal/llm/model_tags.go
+++ b/internal/llm/model_tags.go
@@ -74,9 +74,11 @@ func (c *Client) GetModelTags(model string, p config.ProviderConfig) (string, bo
 	var shouldDisable, shouldDelete bool
 	var err error
 
-	switch p.Type {
-	case config.ProviderTypeAnthropic:
+	switch {
+	case p.Type == config.ProviderTypeAnthropic:
 		tags, shouldDisable, shouldDelete, err = c.getTagsAnthropic(model, p)
+	case p.UsesResponsesAPI():
+		tags, shouldDisable, shouldDelete, err = c.getTagsOpenAIResponses(model, p)
 	default:
 		tags, shouldDisable, shouldDelete, err = c.getTagsOpenAICompatible(model, p)
 	}
@@ -390,6 +392,65 @@ func (c *Client) getTagsOpenAICompatibleUserRoleOnly(model string, p config.Prov
 	}
 
 	return c.extractTagsFromOpenAIResponse(responseBody.Bytes(), model)
+}
+
+// getTagsOpenAIResponses fetches capability tags via the OpenAI Responses API.
+// It mirrors getTagsOpenAICompatible but sends the prompt in "input" and reads the
+// answer from "output". temperature and max_output_tokens are omitted so reasoning
+// models are not rejected and are free to allocate their own output budget.
+func (c *Client) getTagsOpenAIResponses(model string, p config.ProviderConfig) (string, bool, bool, error) {
+	if isKnownNonChatModel(model) {
+		log.Printf("Model %s identified as non-chat model by name — deleting", model)
+		return "", false, true, nil
+	}
+
+	url := p.ResponsesURL()
+
+	var messages []map[string]interface{}
+	if isReasoningModelNoSysMsg(model) {
+		messages = []map[string]interface{}{
+			{"role": "user", "content": c.activeTaggingUserNoSysPrompt()},
+		}
+	} else {
+		messages = []map[string]interface{}{
+			{"role": "system", "content": c.activeTaggingSystemPrompt()},
+			{"role": "user", "content": c.activeTaggingUserPrompt()},
+		}
+	}
+
+	payload := buildResponsesPayload(model, messages, responsesRequestOptions{})
+
+	log.Printf("Sending tags request to %s for model %s", url, model)
+	body, status, err := sendResponsesRequest(url, p.APIKey, payload, p.Timeout)
+	if err != nil {
+		return "", false, false, err
+	}
+	log.Printf("Raw tags response for model %s: %s", model, string(body))
+
+	if status >= 400 {
+		msg := extractAPIErrorMessage(body)
+		if msg != "" {
+			log.Printf("API error for model %s (HTTP %d): %s", model, status, msg)
+			// Not a chat model at all (e.g. completion-only, image, embedding).
+			if strings.Contains(msg, "This is not a chat model") ||
+				strings.Contains(msg, "not supported in the v1/chat/completions endpoint") {
+				return "", false, true, nil
+			}
+			// Audio/vision/modality-only models.
+			if IsModelIncompatibleError(msg) {
+				return `{"strengths":["unavailable"],"weaknesses":["text-incompatible"]}`, true, false, nil
+			}
+		}
+		// Unknown 4xx — fall through; extraction will surface the error.
+	}
+
+	content, err := extractResponsesContent(body)
+	if err != nil {
+		return "", false, false, err
+	}
+	extracted := c.extractJSON(content)
+	log.Printf("Model %s (responses) extracted tags: %s", model, extracted)
+	return extracted, false, false, nil
 }
 
 // getTagsAnthropic fetches capability tags using the Anthropic Messages API.

--- a/internal/llm/responses.go
+++ b/internal/llm/responses.go
@@ -1,0 +1,153 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// The OpenAI Responses API (https://platform.openai.com/docs/api-reference/responses)
+// differs from Chat Completions in two ways relevant to PiPiMink:
+//
+//   - Request: the conversation is passed in "input" (an array of role/content items or
+//     a plain string) instead of "messages".
+//   - Response: generated text lives in an "output" array. Each item may be a
+//     "reasoning" block (skipped) or a "message" block whose "content" array holds
+//     "output_text" parts. There is no "choices" array.
+//
+// Azure AI Foundry serves OpenAI deployments through this API at
+// {base}/openai/v1/responses. This file provides the request builder and response
+// parser shared by tagging, chat, model selection, and the benchmark judge.
+
+// responsesRequestOptions controls optional fields on a Responses API request.
+// Temperature and max_output_tokens are omitted by default because reasoning models
+// (o-series, gpt-5.x) reject temperature and count reasoning tokens against the
+// output budget, which makes a small fixed budget truncate the answer.
+type responsesRequestOptions struct {
+	temperature     *float64
+	maxOutputTokens int
+}
+
+// buildResponsesInput converts an OpenAI-format messages array into the Responses API
+// "input" array. Roles are preserved (the Responses API accepts system, developer,
+// user, and assistant), and string content is passed through unchanged.
+func buildResponsesInput(messages []map[string]interface{}) []map[string]interface{} {
+	input := make([]map[string]interface{}, 0, len(messages))
+	for _, m := range messages {
+		role, _ := m["role"].(string)
+		if role == "" {
+			continue
+		}
+		input = append(input, map[string]interface{}{
+			"role":    role,
+			"content": m["content"],
+		})
+	}
+	return input
+}
+
+// buildResponsesPayload assembles a Responses API request body from a messages array.
+func buildResponsesPayload(model string, messages []map[string]interface{}, opts responsesRequestOptions) map[string]interface{} {
+	payload := map[string]interface{}{
+		"model": model,
+		"input": buildResponsesInput(messages),
+	}
+	if opts.temperature != nil {
+		payload["temperature"] = *opts.temperature
+	}
+	if opts.maxOutputTokens > 0 {
+		payload["max_output_tokens"] = opts.maxOutputTokens
+	}
+	return payload
+}
+
+// sendResponsesRequest POSTs a Responses API payload and returns the raw response body
+// and HTTP status code. Authentication uses a Bearer token, which both the public
+// OpenAI Responses API and Azure AI Foundry's /openai/v1 surface accept.
+func sendResponsesRequest(url, apiKey string, payload map[string]interface{}, timeout time.Duration) ([]byte, int, error) {
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error marshalling Responses payload: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return nil, 0, fmt.Errorf("error creating Responses request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error making Responses request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var buf bytes.Buffer
+	if _, err = buf.ReadFrom(resp.Body); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("error reading Responses body: %w", err)
+	}
+	return buf.Bytes(), resp.StatusCode, nil
+}
+
+// extractResponsesContent parses the generated text from an OpenAI Responses API body.
+//
+// It concatenates the text of every "output_text" part inside "message" items, skipping
+// "reasoning" and other non-message items. It also honours a top-level "output_text"
+// convenience field when present, surfaces API "error" objects, and reports truncation
+// via "incomplete_details".
+func extractResponsesContent(body []byte) (string, error) {
+	var result struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		OutputText        string `json:"output_text"`
+		IncompleteDetails *struct {
+			Reason string `json:"reason"`
+		} `json:"incomplete_details"`
+		Output []struct {
+			Type    string `json:"type"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("error decoding Responses API response: %w", err)
+	}
+
+	if result.Error != nil && result.Error.Message != "" {
+		return "", fmt.Errorf("API error: %s", result.Error.Message)
+	}
+
+	var sb strings.Builder
+	for _, item := range result.Output {
+		if item.Type != "message" {
+			continue
+		}
+		for _, part := range item.Content {
+			if part.Type == "output_text" {
+				sb.WriteString(part.Text)
+			}
+		}
+	}
+	text := sb.String()
+	if text == "" && result.OutputText != "" {
+		text = result.OutputText
+	}
+
+	if text == "" {
+		if result.IncompleteDetails != nil && result.IncompleteDetails.Reason == "max_output_tokens" {
+			return "", fmt.Errorf("response truncated at max_output_tokens before any text was produced (reasoning consumed the output budget)")
+		}
+		return "", fmt.Errorf("missing text in Responses API output")
+	}
+	return text, nil
+}

--- a/internal/llm/responses_test.go
+++ b/internal/llm/responses_test.go
@@ -1,0 +1,101 @@
+package llm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildResponsesInput(t *testing.T) {
+	messages := []map[string]interface{}{
+		{"role": "system", "content": "sys"},
+		{"role": "user", "content": "hi"},
+		{"content": "no-role-dropped"},
+	}
+	input := buildResponsesInput(messages)
+	assert.Len(t, input, 2)
+	assert.Equal(t, "system", input[0]["role"])
+	assert.Equal(t, "sys", input[0]["content"])
+	assert.Equal(t, "user", input[1]["role"])
+}
+
+func TestBuildResponsesPayload(t *testing.T) {
+	messages := []map[string]interface{}{
+		{"role": "user", "content": "hi"},
+	}
+
+	// Defaults omit temperature and max_output_tokens (reasoning-model safe).
+	payload := buildResponsesPayload("gpt-5", messages, responsesRequestOptions{})
+	assert.Equal(t, "gpt-5", payload["model"])
+	_, hasMessages := payload["messages"]
+	assert.False(t, hasMessages, "must not send 'messages' to the Responses API")
+	_, hasInput := payload["input"]
+	assert.True(t, hasInput, "must send 'input' to the Responses API")
+	_, hasTemp := payload["temperature"]
+	assert.False(t, hasTemp)
+	_, hasMax := payload["max_output_tokens"]
+	assert.False(t, hasMax)
+
+	// Options are honoured when set.
+	temp := 0.0
+	payload = buildResponsesPayload("gpt-5", messages, responsesRequestOptions{temperature: &temp, maxOutputTokens: 256})
+	assert.Equal(t, 0.0, payload["temperature"])
+	assert.Equal(t, 256, payload["max_output_tokens"])
+
+	// The marshalled body must contain "input" and not "messages".
+	raw, err := json.Marshal(payload)
+	assert.NoError(t, err)
+	assert.Contains(t, string(raw), `"input"`)
+	assert.NotContains(t, string(raw), `"messages"`)
+}
+
+func TestExtractResponsesContent(t *testing.T) {
+	t.Run("Single message with output_text", func(t *testing.T) {
+		body := []byte(`{"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello world"}]}]}`)
+		content, err := extractResponsesContent(body)
+		assert.NoError(t, err)
+		assert.Equal(t, "hello world", content)
+	})
+
+	t.Run("Reasoning item before message", func(t *testing.T) {
+		body := []byte(`{"output":[{"type":"reasoning","summary":[]},{"type":"message","content":[{"type":"output_text","text":"answer"}]}]}`)
+		content, err := extractResponsesContent(body)
+		assert.NoError(t, err)
+		assert.Equal(t, "answer", content)
+	})
+
+	t.Run("Multiple output_text parts concatenated", func(t *testing.T) {
+		body := []byte(`{"output":[{"type":"message","content":[{"type":"output_text","text":"a"},{"type":"output_text","text":"b"}]}]}`)
+		content, err := extractResponsesContent(body)
+		assert.NoError(t, err)
+		assert.Equal(t, "ab", content)
+	})
+
+	t.Run("Top-level output_text fallback", func(t *testing.T) {
+		body := []byte(`{"output_text":"convenience","output":[]}`)
+		content, err := extractResponsesContent(body)
+		assert.NoError(t, err)
+		assert.Equal(t, "convenience", content)
+	})
+
+	t.Run("API error surfaced", func(t *testing.T) {
+		body := []byte(`{"error":{"message":"Unsupported parameter: 'messages'."}}`)
+		_, err := extractResponsesContent(body)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "messages")
+	})
+
+	t.Run("Truncation via incomplete_details", func(t *testing.T) {
+		body := []byte(`{"output":[],"incomplete_details":{"reason":"max_output_tokens"}}`)
+		_, err := extractResponsesContent(body)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "max_output_tokens")
+	})
+
+	t.Run("Empty output", func(t *testing.T) {
+		body := []byte(`{"output":[]}`)
+		_, err := extractResponsesContent(body)
+		assert.Error(t, err)
+	})
+}

--- a/providers.example.json
+++ b/providers.example.json
@@ -81,6 +81,12 @@
         "name": "gpt-4o",
         "chat_path": "/api/projects/YOUR-PROJECT-NAME/openai/v1/chat/completions",
         "api_key_env": "AZURE_FOUNDRY_GPT4O_API_KEY"
+      },
+      {
+        "name": "gpt-5",
+        "type": "openai-responses",
+        "chat_path": "/openai/v1/responses",
+        "api_key_env": "AZURE_FOUNDRY_GPT5_API_KEY"
       }
     ]
   }

--- a/web/console/src/components/provider-management/ModelConfigTable.tsx
+++ b/web/console/src/components/provider-management/ModelConfigTable.tsx
@@ -81,6 +81,7 @@ function ConfigForm({
         >
           <option value="">Inherit from provider</option>
           <option value="openai-compatible">openai-compatible</option>
+          <option value="openai-responses">openai-responses</option>
           <option value="anthropic">anthropic</option>
         </select>
       </div>
@@ -113,6 +114,11 @@ function ConfigForm({
           placeholder="/models/chat/completions?api-version=..."
           className="w-full px-2.5 py-1.5 text-sm font-mono rounded-md border border-slate-200 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
         />
+        <p className="mt-1 text-[10px] text-slate-400 dark:text-slate-500">
+          Azure AI Foundry OpenAI (Responses API): set type to{' '}
+          <span className="font-mono">openai-responses</span> and path to{' '}
+          <span className="font-mono">/openai/v1/responses</span>.
+        </p>
       </div>
 
       <div>

--- a/web/console/src/components/provider-management/ProviderList.tsx
+++ b/web/console/src/components/provider-management/ProviderList.tsx
@@ -15,6 +15,12 @@ function typeBadge(type: string): { label: string; bg: string; text: string } {
         bg: 'bg-amber-50 dark:bg-amber-900/30',
         text: 'text-amber-700 dark:text-amber-300',
       }
+    case 'openai-responses':
+      return {
+        label: 'OpenAI Responses',
+        bg: 'bg-violet-50 dark:bg-violet-900/30',
+        text: 'text-violet-700 dark:text-violet-300',
+      }
     default:
       return {
         label: 'OpenAI',

--- a/web/console/src/components/provider-management/ProviderModal.tsx
+++ b/web/console/src/components/provider-management/ProviderModal.tsx
@@ -88,6 +88,7 @@ export function ProviderModal({ provider, onSave, onClose }: ProviderModalProps)
               className="w-full px-3 py-2 text-sm rounded-lg border border-slate-200 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-300 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 transition-colors"
             >
               <option value="openai-compatible">openai-compatible</option>
+              <option value="openai-responses">openai-responses</option>
               <option value="anthropic">anthropic</option>
             </select>
           </div>

--- a/web/console/src/types/provider-management.ts
+++ b/web/console/src/types/provider-management.ts
@@ -1,5 +1,5 @@
 /** Provider type identifier */
-export type ProviderType = 'openai-compatible' | 'anthropic'
+export type ProviderType = 'openai-compatible' | 'openai-responses' | 'anthropic'
 
 /** Result of a connectivity test */
 export type TestResult = 'success' | 'error'


### PR DESCRIPTION
## What

Adds support for Azure AI Foundry OpenAI models served through the **OpenAI Responses API** (`/openai/v1/responses`).

Fixes #47.

## Why

Azure AI Foundry now serves OpenAI deployments (e.g. `gpt-5.x`) via the Responses API, which replaces the Chat Completions `messages` field with `input` and returns an `output` array instead of `choices`. PiPiMink only spoke Chat Completions, so tagging/chat/routing/benchmarking failed with:

```
HTTP 400: Unsupported parameter: 'messages'. In the Responses API, this parameter has moved to 'input'.
tag: error tagging model gpt-5.6-terra (az-foundry): missing or empty choices in response
```

…and the model was auto-disabled.

## How

**Backend**
- New provider type `openai-responses`, plus **auto-detection** when a `chat_path` targets `/responses` (so existing path-only overrides work and future migrations keep working).
- New `ProviderConfig.UsesResponsesAPI()` and `ResponsesURL()` helpers.
- New `internal/llm/responses.go`: request builder (`input`) and a robust response parser (`output` → `message` → `output_text`, with `error` and `incomplete_details` handling).
- Wired into tagging, chat, model selection, and the benchmark judge.
- `temperature` and `max_output_tokens` are omitted by default so reasoning models (o-series, gpt-5.x) are not rejected and manage their own output budget.

**Frontend**
- `openai-responses` added to the type union, the provider and per-model type selectors, a provider-list badge, and a chat-path hint.

**Docs & config**
- README, SETUP (new endpoint pattern + diagram/table/example), CHANGELOG, AGENTS, copilot-instructions, `providers.example.json`, `.env.example`.

## Testing

- `go build ./...`, `go test -short ./...` — all pass.
- New unit tests: `UsesResponsesAPI`/`ResponsesURL`/`ForModel` override; `buildResponsesInput`/`buildResponsesPayload`/`extractResponsesContent`; an end-to-end chat test asserting the `/responses` endpoint is hit and the body uses `input` (not `messages`).
- Frontend: `tsc --noEmit`, `vitest run` (22 passed), `npm run build` — all pass.
- `markdownlint-cli2` — 0 errors.

## How to configure

```json
{
  "name": "gpt-5",
  "type": "openai-responses",
  "chat_path": "/openai/v1/responses",
  "api_key_env": "AZURE_FOUNDRY_GPT5_API_KEY"
}
```
