### PR TITLE
feat(benchmark): functional LLM-judge strictness (1–5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.0] — Authentication, Console & Judge Strictness
+
 ### Added
 
+- **Benchmark judge strictness** (replaces the previously cosmetic "Difficulty" slider): each `llm-judge` task now carries a `judge_strictness` level (1 = lenient … 5 = strict, default 3). The level is persisted and injected into the judge system prompt, so the evaluator grades anywhere from "reward partial correctness" up to "demand a near-perfect match to the criteria". Adds a `judge_strictness` column to `benchmark_task_configs` (additive migration, defaults to 3); the console TaskForm/TaskCard now show a "Judge Strictness" control only for LLM-judge tasks. Fixes #50.
 - Azure AI Foundry OpenAI models via the **Responses API** (`/openai/v1/responses`): new provider type `openai-responses` (plus auto-detection when a `chat_path` targets `/responses`). Requests use the `input` field and responses are parsed from the `output` array, so Foundry OpenAI deployments (e.g. `gpt-5.x`) can be tagged, routed, chatted, and benchmarked. `temperature` and `max_output_tokens` are omitted by default so reasoning models are not rejected. The console UI exposes the new type in the provider and per-model selectors. Fixes #47.
 - 3-tier authentication model: Public (unauthenticated), User (session or Bearer token), Admin (X-API-Key or admin session)
   - Centralized auth middleware enforces tiers on all routes — new handlers must not perform inline auth checks

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ See [SETUP.md](SETUP.md#authentication) for full configuration details.
 
 LLM-judge tasks use a configurable judge model (`BENCHMARK_JUDGE_PROVIDER` / `BENCHMARK_JUDGE_MODEL`). Each criterion is scored independently on a 0–10 scale; the final score is the average across all criteria. This gives fine-grained, continuous scores rather than binary pass/fail.
 
+Each LLM-judge task also has a **judge strictness** level from 1 (lenient) to 5 (strict), default 3. Strictness controls how harshly the judge grades: at level 1 it rewards answers that are roughly or partially correct, while at level 5 it only awards high scores for a near-perfect match to the criteria. Set it per task in the console's Config / Benchmarks section.
+
 Benchmark scores feed directly into routing decisions as the secondary signal after capability tags, pushing traffic toward models that empirically perform better on the types of tasks you actually run.
 
 ## Architecture

--- a/internal/benchmark/scorer.go
+++ b/internal/benchmark/scorer.go
@@ -88,8 +88,10 @@ func (s *Scorer) scoreLLMJudge(ctx context.Context, task Task, response string) 
 	systemMsg := fmt.Sprintf(
 		"You are an objective AI response evaluator. Score each criterion independently on a scale of 0 to 10.\n"+
 			"Use the full range: 0=completely missing or wrong, 3=poor, 5=mediocre, 7=good, 9=excellent, 10=perfect.\n"+
+			"%s\n"+
 			"Return ONLY a JSON object in this exact format (no other text):\n"+
 			"{\"scores\": {%s}, \"reason\": \"<one sentence overall summary>\"}",
+		strictnessGuidance(task.JudgeStrictness),
 		strings.Join(exampleKeys, ", "),
 	)
 
@@ -190,6 +192,30 @@ func (s *Scorer) scoreLLMJudge(ctx context.Context, task Task, response string) 
 	normalised := (sum / float64(len(judgeResult.Scores))) / 10.0
 	log.Printf("benchmark: judge scores %v (avg=%.2f) for task %s — %s", judgeResult.Scores, normalised, task.ID, judgeResult.Reason)
 	return normalised
+}
+
+// strictnessGuidance returns a grading-severity instruction for the judge system prompt,
+// keyed by a task's JudgeStrictness level (1=lenient … 5=strict). The level is normalised
+// to [1,5] first, with the zero value mapped to the neutral default.
+func strictnessGuidance(level int) string {
+	switch NormalizeStrictness(level) {
+	case 1:
+		return "Grading severity: VERY LENIENT. Reward effort and partial correctness generously. " +
+			"Award high scores as long as the response is roughly on the right track or approximately correct. " +
+			"Do not penalise minor errors, omissions, style, or missing detail."
+	case 2:
+		return "Grading severity: LENIENT. Give the response the benefit of the doubt. " +
+			"Award high scores when the core of the answer is correct, treating small mistakes and omissions gently."
+	case 3:
+		return "Grading severity: BALANCED. Grade fairly and objectively, using the full range of scores. " +
+			"Reward what is correct and deduct proportionally for genuine errors or omissions."
+	case 4:
+		return "Grading severity: STRICT. Hold the response closely to each criterion. " +
+			"Penalise inaccuracies, omissions, and deviations from the ideal answer; only well-executed responses should score highly."
+	default: // 5
+		return "Grading severity: VERY STRICT. Demand near-perfect adherence to every criterion. " +
+			"Award high scores only when the response is essentially flawless and complete; any inaccuracy, omission, or deviation must substantially lower the score."
+	}
 }
 
 // buildOpenAIRequest builds the JSON payload and URL for an OpenAI-compatible judge request.

--- a/internal/benchmark/strictness_test.go
+++ b/internal/benchmark/strictness_test.go
@@ -1,0 +1,72 @@
+package benchmark
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeStrictness(t *testing.T) {
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{0, DefaultJudgeStrictness}, // unset maps to default
+		{-3, 1},                     // below range clamps to 1
+		{1, 1},
+		{3, 3},
+		{5, 5},
+		{9, 5}, // above range clamps to 5
+	}
+	for _, c := range cases {
+		if got := NormalizeStrictness(c.in); got != c.want {
+			t.Errorf("NormalizeStrictness(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStrictnessGuidanceVariesByLevel(t *testing.T) {
+	// Each level (after normalisation) must yield a distinct, non-empty instruction
+	// so the judge prompt actually changes with the configured strictness.
+	seen := make(map[string]int)
+	for level := 1; level <= 5; level++ {
+		g := strictnessGuidance(level)
+		if strings.TrimSpace(g) == "" {
+			t.Fatalf("strictnessGuidance(%d) returned empty string", level)
+		}
+		if prev, ok := seen[g]; ok {
+			t.Errorf("strictnessGuidance(%d) duplicates guidance for level %d", level, prev)
+		}
+		seen[g] = level
+	}
+}
+
+func TestStrictnessGuidanceEndpoints(t *testing.T) {
+	if !strings.Contains(strictnessGuidance(1), "LENIENT") {
+		t.Errorf("level 1 guidance should be lenient: %q", strictnessGuidance(1))
+	}
+	if !strings.Contains(strictnessGuidance(5), "STRICT") {
+		t.Errorf("level 5 guidance should be strict: %q", strictnessGuidance(5))
+	}
+	// The zero value (unset) must fall back to the balanced default.
+	if strictnessGuidance(0) != strictnessGuidance(DefaultJudgeStrictness) {
+		t.Errorf("unset strictness should match default guidance")
+	}
+}
+
+func TestTasksFromConfigsNormalisesStrictness(t *testing.T) {
+	cfgs := []BenchmarkTaskConfig{
+		{TaskID: "a", Category: "coding", ScoringMethod: "llm-judge", JudgeStrictness: 0, Enabled: true},
+		{TaskID: "b", Category: "coding", ScoringMethod: "llm-judge", JudgeStrictness: 5, Enabled: true},
+		{TaskID: "c", Category: "coding", ScoringMethod: "llm-judge", JudgeStrictness: 42, Enabled: true},
+	}
+	tasks := TasksFromConfigs(cfgs)
+	if len(tasks) != 3 {
+		t.Fatalf("expected 3 tasks, got %d", len(tasks))
+	}
+	want := map[string]int{"a": DefaultJudgeStrictness, "b": 5, "c": 5}
+	for _, tk := range tasks {
+		if tk.JudgeStrictness != want[tk.ID] {
+			t.Errorf("task %s: JudgeStrictness = %d, want %d", tk.ID, tk.JudgeStrictness, want[tk.ID])
+		}
+	}
+}

--- a/internal/benchmark/task.go
+++ b/internal/benchmark/task.go
@@ -53,6 +53,25 @@ type JudgeCriterion struct {
 	Description string // what the judge should look for
 }
 
+// DefaultJudgeStrictness is the neutral judge-strictness level applied when a task
+// does not specify one. 1 = most lenient, 5 = most strict.
+const DefaultJudgeStrictness = 3
+
+// NormalizeStrictness clamps a judge-strictness level to the valid [1,5] range,
+// mapping the zero value (unset) to DefaultJudgeStrictness.
+func NormalizeStrictness(level int) int {
+	if level == 0 {
+		return DefaultJudgeStrictness
+	}
+	if level < 1 {
+		return 1
+	}
+	if level > 5 {
+		return 5
+	}
+	return level
+}
+
 // Task defines a single benchmark task.
 type Task struct {
 	ID              string
@@ -62,6 +81,7 @@ type Task struct {
 	ExpectedAnswer  string               // ScoringDeterministic: response must contain this string (case-insensitive)
 	FormatValidator func(string) float64 // ScoringFormat: returns 0.0–1.0
 	JudgeCriteria   []JudgeCriterion     // ScoringLLMJudge: each criterion is scored 0–10 independently; final score = average
+	JudgeStrictness int                  // ScoringLLMJudge: how harshly the judge grades (1=lenient … 5=strict); 0 = DefaultJudgeStrictness
 }
 
 // AllTasks returns the full task registry.
@@ -87,15 +107,16 @@ var registeredTasks = buildTasks()
 // ScoringFormat tasks store only the prompt here; their validator is looked up at runtime
 // via builtinFormatValidators keyed by TaskID.
 type BenchmarkTaskConfig struct {
-	TaskID         string           `json:"task_id"`
-	Category       string           `json:"category"`
-	Prompt         string           `json:"prompt"`
-	ScoringMethod  string           `json:"scoring_method"`
-	ExpectedAnswer string           `json:"expected_answer,omitempty"`
-	JudgeCriteria  []JudgeCriterion `json:"judge_criteria,omitempty"`
-	Enabled        bool             `json:"enabled"`
-	IsBuiltin      bool             `json:"is_builtin"`
-	UpdatedAt      string           `json:"updated_at,omitempty"`
+	TaskID          string           `json:"task_id"`
+	Category        string           `json:"category"`
+	Prompt          string           `json:"prompt"`
+	ScoringMethod   string           `json:"scoring_method"`
+	ExpectedAnswer  string           `json:"expected_answer,omitempty"`
+	JudgeCriteria   []JudgeCriterion `json:"judge_criteria,omitempty"`
+	JudgeStrictness int              `json:"judge_strictness,omitempty"`
+	Enabled         bool             `json:"enabled"`
+	IsBuiltin       bool             `json:"is_builtin"`
+	UpdatedAt       string           `json:"updated_at,omitempty"`
 }
 
 // builtinFormatValidators maps task IDs for ScoringFormat tasks to their Go validator functions.
@@ -117,14 +138,15 @@ func DefaultTaskConfigs() []BenchmarkTaskConfig {
 	cfgs := make([]BenchmarkTaskConfig, 0, len(registeredTasks))
 	for _, t := range registeredTasks {
 		cfgs = append(cfgs, BenchmarkTaskConfig{
-			TaskID:         t.ID,
-			Category:       string(t.Category),
-			Prompt:         t.Prompt,
-			ScoringMethod:  string(t.ScoringMethod),
-			ExpectedAnswer: t.ExpectedAnswer,
-			JudgeCriteria:  t.JudgeCriteria,
-			Enabled:        true,
-			IsBuiltin:      true,
+			TaskID:          t.ID,
+			Category:        string(t.Category),
+			Prompt:          t.Prompt,
+			ScoringMethod:   string(t.ScoringMethod),
+			ExpectedAnswer:  t.ExpectedAnswer,
+			JudgeCriteria:   t.JudgeCriteria,
+			JudgeStrictness: NormalizeStrictness(t.JudgeStrictness),
+			Enabled:         true,
+			IsBuiltin:       true,
 		})
 	}
 	return cfgs
@@ -140,12 +162,13 @@ func TasksFromConfigs(configs []BenchmarkTaskConfig) []Task {
 			continue
 		}
 		t := Task{
-			ID:             c.TaskID,
-			Category:       Category(c.Category),
-			Prompt:         c.Prompt,
-			ScoringMethod:  ScoringMethod(c.ScoringMethod),
-			ExpectedAnswer: c.ExpectedAnswer,
-			JudgeCriteria:  c.JudgeCriteria,
+			ID:              c.TaskID,
+			Category:        Category(c.Category),
+			Prompt:          c.Prompt,
+			ScoringMethod:   ScoringMethod(c.ScoringMethod),
+			ExpectedAnswer:  c.ExpectedAnswer,
+			JudgeCriteria:   c.JudgeCriteria,
+			JudgeStrictness: NormalizeStrictness(c.JudgeStrictness),
 		}
 		if t.ScoringMethod == ScoringFormat {
 			t.FormatValidator = builtinFormatValidators[c.TaskID]

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -569,6 +569,8 @@ func (db *DB) initConfigSchema() error {
 		is_builtin     BOOLEAN NOT NULL DEFAULT TRUE,
 		updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
 	);
+	ALTER TABLE benchmark_task_configs
+		ADD COLUMN IF NOT EXISTS judge_strictness INT NOT NULL DEFAULT 3;
 	CREATE TABLE IF NOT EXISTS system_prompts (
 		key        TEXT PRIMARY KEY,
 		value      TEXT NOT NULL,
@@ -605,6 +607,7 @@ func (db *DB) GetBenchmarkTaskConfigs() ([]benchmark.BenchmarkTaskConfig, error)
 	rows, err := db.Query(`
 		SELECT task_id, category, prompt, scoring_method,
 		       COALESCE(expected_answer,''), COALESCE(judge_criteria,'null'::jsonb),
+		       COALESCE(judge_strictness,3),
 		       enabled, is_builtin, updated_at
 		FROM benchmark_task_configs
 		ORDER BY category, task_id
@@ -622,6 +625,7 @@ func (db *DB) GetBenchmarkTaskConfigs() ([]benchmark.BenchmarkTaskConfig, error)
 		if err := rows.Scan(
 			&c.TaskID, &c.Category, &c.Prompt, &c.ScoringMethod,
 			&c.ExpectedAnswer, &criteriaJSON,
+			&c.JudgeStrictness,
 			&c.Enabled, &c.IsBuiltin, &updatedAt,
 		); err != nil {
 			log.Printf("db: error scanning benchmark task config row: %v", err)
@@ -644,18 +648,19 @@ func (db *DB) UpsertBenchmarkTaskConfig(cfg benchmark.BenchmarkTaskConfig) error
 	}
 	_, err = db.Exec(`
 		INSERT INTO benchmark_task_configs
-			(task_id, category, prompt, scoring_method, expected_answer, judge_criteria, enabled, is_builtin, updated_at)
-		VALUES ($1,$2,$3,$4,$5,$6::jsonb,$7,$8,NOW())
+			(task_id, category, prompt, scoring_method, expected_answer, judge_criteria, judge_strictness, enabled, is_builtin, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6::jsonb,$7,$8,$9,NOW())
 		ON CONFLICT (task_id) DO UPDATE SET
 			category       = EXCLUDED.category,
 			prompt         = EXCLUDED.prompt,
 			scoring_method = EXCLUDED.scoring_method,
 			expected_answer= EXCLUDED.expected_answer,
 			judge_criteria = EXCLUDED.judge_criteria,
+			judge_strictness = EXCLUDED.judge_strictness,
 			enabled        = EXCLUDED.enabled,
 			updated_at     = NOW()
 	`, cfg.TaskID, cfg.Category, cfg.Prompt, cfg.ScoringMethod,
-		cfg.ExpectedAnswer, string(criteriaJSON), cfg.Enabled, cfg.IsBuiltin)
+		cfg.ExpectedAnswer, string(criteriaJSON), benchmark.NormalizeStrictness(cfg.JudgeStrictness), cfg.Enabled, cfg.IsBuiltin)
 	if err != nil {
 		return fmt.Errorf("error upserting benchmark task config: %w", err)
 	}

--- a/internal/database/database_sqlmock_test.go
+++ b/internal/database/database_sqlmock_test.go
@@ -212,6 +212,8 @@ func TestInitSchema_ColumnsAlreadyExist(t *testing.T) {
 		is_builtin     BOOLEAN NOT NULL DEFAULT TRUE,
 		updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
 	);
+	ALTER TABLE benchmark_task_configs
+		ADD COLUMN IF NOT EXISTS judge_strictness INT NOT NULL DEFAULT 3;
 	CREATE TABLE IF NOT EXISTS system_prompts (
 		key        TEXT PRIMARY KEY,
 		value      TEXT NOT NULL,

--- a/web/console/package-lock.json
+++ b/web/console/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipimink-console",
-  "version": "0.0.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pipimink-console",
-      "version": "0.0.1",
+      "version": "0.6.0",
       "dependencies": {
         "lucide-react": "^0.511.0",
         "react": "^19.1.0",

--- a/web/console/package.json
+++ b/web/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pipimink-console",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/console/src/api/config.ts
+++ b/web/console/src/api/config.ts
@@ -22,6 +22,7 @@ interface BackendBenchmarkTask {
   scoring_method: string
   expected_answer: string
   judge_criteria: BackendJudgeCriterion[] | null
+  judge_strictness: number
   enabled: boolean
   is_builtin: boolean
   updated_at: string
@@ -76,7 +77,7 @@ function transformTask(t: BackendBenchmarkTask): BenchmarkTask {
       ? t.judge_criteria.map((c) => ({ name: c.Name, description: c.Description }))
       : null,
     expectedAnswer: t.expected_answer || null,
-    difficulty: 3,
+    judgeStrictness: t.judge_strictness || 3,
     enabled: t.enabled,
     builtin: t.is_builtin,
     resultCount: 0,
@@ -100,6 +101,7 @@ function toBackendTask(
     scoring_method: task.scoringMethod,
     expected_answer: task.expectedAnswer ?? '',
     judge_criteria: criteria,
+    judge_strictness: task.judgeStrictness ?? 3,
     enabled: task.enabled,
     is_builtin: task.builtin,
     updated_at: '',

--- a/web/console/src/components/config-and-benchmarks/TaskCard.tsx
+++ b/web/console/src/components/config-and-benchmarks/TaskCard.tsx
@@ -166,9 +166,11 @@ export function TaskCard({
               <ScoringIcon className="w-3 h-3" strokeWidth={2} />
               {task.scoringMethod}
             </span>
-            <span className="text-[10px] text-slate-400 dark:text-slate-500">
-              Diff {task.difficulty}/5
-            </span>
+            {task.scoringMethod === 'llm-judge' && (
+              <span className="text-[10px] text-slate-400 dark:text-slate-500">
+                Strictness {task.judgeStrictness}/5
+              </span>
+            )}
             <span className="text-[10px] text-slate-400 dark:text-slate-500">
               {task.resultCount} result{task.resultCount !== 1 ? 's' : ''}
             </span>

--- a/web/console/src/components/config-and-benchmarks/TaskForm.tsx
+++ b/web/console/src/components/config-and-benchmarks/TaskForm.tsx
@@ -28,7 +28,7 @@ export function TaskForm({ task, existingCategories, onSave, onCancel }: TaskFor
     task?.judgeCriteria ?? [{ name: '', description: '' }]
   )
   const [expectedAnswer, setExpectedAnswer] = useState(task?.expectedAnswer ?? '')
-  const [difficulty, setDifficulty] = useState(task?.difficulty ?? 3)
+  const [judgeStrictness, setJudgeStrictness] = useState(task?.judgeStrictness ?? 3)
   const [enabled, setEnabled] = useState(task?.enabled ?? true)
 
   const isEditing = !!task
@@ -59,7 +59,7 @@ export function TaskForm({ task, existingCategories, onSave, onCancel }: TaskFor
           ? judgeCriteria.filter((c) => c.name.trim() || c.description.trim())
           : null,
       expectedAnswer: scoringMethod === 'deterministic' ? expectedAnswer || null : null,
-      difficulty,
+      judgeStrictness,
       enabled,
       builtin: task?.builtin ?? false,
     })
@@ -136,7 +136,7 @@ export function TaskForm({ task, existingCategories, onSave, onCancel }: TaskFor
         />
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {/* Scoring Method */}
         <div>
           <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
@@ -156,26 +156,6 @@ export function TaskForm({ task, existingCategories, onSave, onCancel }: TaskFor
           <p className="mt-0.5 text-[10px] text-slate-400 dark:text-slate-500">
             {scoringMethods.find((m) => m.value === scoringMethod)?.description}
           </p>
-        </div>
-
-        {/* Difficulty */}
-        <div>
-          <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
-            Difficulty (1–5)
-          </label>
-          <div className="flex items-center gap-2">
-            <input
-              type="range"
-              min={1}
-              max={5}
-              value={difficulty}
-              onChange={(e) => setDifficulty(Number(e.target.value))}
-              className="flex-1 accent-indigo-500"
-            />
-            <span className="w-6 text-center text-sm font-mono font-medium text-slate-700 dark:text-slate-300">
-              {difficulty}
-            </span>
-          </div>
         </div>
 
         {/* Enabled */}
@@ -201,6 +181,37 @@ export function TaskForm({ task, existingCategories, onSave, onCancel }: TaskFor
           </button>
         </div>
       </div>
+
+      {/* Judge Strictness — only meaningful for LLM Judge scoring */}
+      {scoringMethod === 'llm-judge' && (
+        <div>
+          <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+            Judge Strictness (1–5)
+          </label>
+          <div className="flex items-center gap-3">
+            <span className="text-[10px] text-slate-400 dark:text-slate-500 shrink-0">
+              Lenient
+            </span>
+            <input
+              type="range"
+              min={1}
+              max={5}
+              value={judgeStrictness}
+              onChange={(e) => setJudgeStrictness(Number(e.target.value))}
+              className="flex-1 accent-indigo-500"
+            />
+            <span className="text-[10px] text-slate-400 dark:text-slate-500 shrink-0">
+              Strict
+            </span>
+            <span className="w-6 text-center text-sm font-mono font-medium text-slate-700 dark:text-slate-300">
+              {judgeStrictness}
+            </span>
+          </div>
+          <p className="mt-0.5 text-[10px] text-slate-400 dark:text-slate-500">
+            How harshly the LLM judge grades: 1 rewards partial correctness, 5 demands a near-perfect match to the criteria.
+          </p>
+        </div>
+      )}
 
       {/* LLM Judge: structured criteria rows */}
       {scoringMethod === 'llm-judge' && (

--- a/web/console/src/types/config-and-benchmarks.ts
+++ b/web/console/src/types/config-and-benchmarks.ts
@@ -18,7 +18,8 @@ export interface BenchmarkTask {
   judgeCriteria: JudgeCriterion[] | null
   /** Used by deterministic: the exact expected answer */
   expectedAnswer: string | null
-  difficulty: number
+  /** Used by llm-judge: how harshly the judge grades (1=lenient … 5=strict) */
+  judgeStrictness: number
   enabled: boolean
   builtin: boolean
   resultCount: number


### PR DESCRIPTION
## Summary

Turns the previously **cosmetic "Difficulty" slider** into a functional **LLM-judge strictness** control. The old `difficulty` field lived only in the frontend, was hardcoded to `3`, never persisted, and had no effect on scoring. It is renamed to **`judge_strictness`** (1 = lenient … 5 = strict, default 3) and wired end-to-end so it changes how harshly the LLM judge grades a response.

Closes #50.

## Changes

### Backend
- `internal/benchmark/task.go`: add `JudgeStrictness` to `Task` and `BenchmarkTaskConfig`, `DefaultJudgeStrictness = 3`, and a `NormalizeStrictness` helper (clamps to [1,5], maps 0 → default); propagated through `DefaultTaskConfigs` / `TasksFromConfigs`.
- `internal/benchmark/scorer.go`: `scoreLLMJudge` injects a strictness-specific grading instruction into the judge system prompt (level 1 rewards partial correctness … level 5 demands a near-perfect match).
- `internal/database/database.go`: additive migration `ALTER TABLE benchmark_task_configs ADD COLUMN IF NOT EXISTS judge_strictness INT NOT NULL DEFAULT 3`; SELECT/UPSERT updated and normalised on write.

### Frontend (console)
- Rename `difficulty` → `judgeStrictness`; now persisted via the API (previously never sent back).
- `TaskForm`: "Judge Strictness (1–5)" slider with lenient/strict markers + helper text, shown **only** for `llm-judge` tasks.
- `TaskCard`: "Strictness X/5" badge shown only for `llm-judge` tasks.

### Tests & docs
- New `internal/benchmark/strictness_test.go` (package previously had no tests); sqlmock schema expectation updated.
- CHANGELOG `0.6.0` release section; README benchmark section documents strictness; frontend version bumped to `0.6.0`.

## Strictness → judge behavior

| Level | Grading severity |
| --- | --- |
| 1 | Very lenient — reward partial/approximate correctness |
| 2 | Lenient — benefit of the doubt |
| 3 (default) | Balanced — fair, full-range grading |
| 4 | Strict — penalise inaccuracies and omissions |
| 5 | Very strict — near-perfect adherence required |

## Validation
- `go test ./...` (short) — pass
- `go vet`, `gofmt` — clean
- `tsc --noEmit` + `vitest run` — pass

## Backward compatibility
- Additive DB migration; existing tasks default to strictness `3`.
- No changes to deterministic/format scoring, routing, or cost behavior.
