### PR TITLE
ci: add GHCR release workflow and multi-arch image publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and release (e.g. v0.6.0)"
+        required: true
+
+permissions:
+  contents: write # create the GitHub Release
+  packages: write # push the image to GHCR
+
+jobs:
+  release:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve release ref
+        id: ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "ref=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern=v{{version}},value=${{ steps.ref.outputs.ref }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.ref.outputs.ref }}
+            type=raw,value=latest
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          version="${{ steps.ref.outputs.ref }}"
+          version="${version#v}"
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
+            flag && /^## \[/ { flag = 0 }
+            flag { print }
+          ' CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            printf 'Release %s\n' "$version" > release_notes.md
+          fi
+          {
+            echo "Docker image:"
+            echo ""
+            echo '```'
+            echo "docker pull ghcr.io/${{ github.repository }}:${version}"
+            echo '```'
+          } >> release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ref.outputs.ref }}
+          name: ${{ steps.ref.outputs.ref }}
+          body_path: release_notes.md
+          make_latest: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Release automation: pushing a `v*.*.*` tag (or running the `Release` workflow manually) now builds a multi-arch Docker image (`linux/amd64`, `linux/arm64`), publishes it to the GitHub Container Registry (`ghcr.io/izzetee/pipimink`) with `vX.Y.Z`, `X.Y`, and `latest` tags, and creates a GitHub Release with notes extracted from this changelog.
+
 ## [0.6.0] — Authentication, Console & Judge Strictness
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,12 @@ WORKDIR /app
 COPY --from=builder /app/pipimink .
 
 # Copy any required configuration files
+# .env.example / providers.example.json are always tracked; real .env and
+# providers.json are optional (gitignored) and normally supplied at runtime via
+# bind mounts. Listing a guaranteed-present file keeps the COPY from failing in CI
+# builds where the real files are absent.
 COPY --from=builder /app/.env* ./
-COPY --from=builder /app/providers.json* ./
+COPY --from=builder /app/providers.example.json /app/providers.json* ./
 
 # Copy static assets for serving
 COPY --from=builder /app/assets ./assets

--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ Open `http://localhost:8080` — the setup wizard will guide you through configu
 
 For file-based configuration or advanced setups (Azure AI Foundry, Authentik OAuth, local development), see **[SETUP.md](SETUP.md)**.
 
+### Container image
+
+Prebuilt multi-arch images (`linux/amd64`, `linux/arm64`) are published to the GitHub Container Registry on every release:
+
+```bash
+docker pull ghcr.io/izzetee/pipimink:latest   # or a specific version, e.g. :v0.6.0
+```
+
 ## AI-Assisted Development
 
 This project was developed with the assistance of AI coding tools. Contributions that use AI are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md#ai-assisted-development) for guidelines.


### PR DESCRIPTION
## Summary

Adds Docker release automation so tagged versions publish a ready-to-run container image.

## Changes

- **New workflow** `.github/workflows/release.yml`:
  - Triggers on `v*.*.*` tag pushes and via manual `workflow_dispatch` (with a `tag` input, so the existing `v0.6.0` tag can be built retroactively).
  - Builds a multi-arch image (`linux/amd64`, `linux/arm64`) with QEMU + Buildx.
  - Publishes to GHCR at `ghcr.io/izzetee/pipimink` with `vX.Y.Z`, `X.Y`, and `latest` tags.
  - Creates a GitHub Release, extracting notes from the matching `CHANGELOG.md` section.
- **Dockerfile**: made the `providers.json` COPY resilient. `providers.json` and `.env` are gitignored, so a fresh CI checkout does not contain them; listing the always-tracked `providers.example.json` keeps the COPY from failing while still copying the real file for local builds.
- **README.md**: documents the published GHCR image and pull command.
- **CHANGELOG.md**: `[Unreleased]` note for the release automation.

## Notes

- Uses only `GITHUB_TOKEN` (no extra secrets); `packages: write` permission is scoped to this workflow.
- The image name is lowercased by `docker/metadata-action`, so `Izzetee/PiPiMink` maps to `ghcr.io/izzetee/pipimink`.
- After merge, the `v0.6.0` tag already exists and will not retro-trigger on push, so the first image can be published by running the workflow manually with input `v0.6.0`.
